### PR TITLE
GH-92: [UI][FOOTER] Update the license in the footer

### DIFF
--- a/src/pages/LandingPage/components/footer.jsx
+++ b/src/pages/LandingPage/components/footer.jsx
@@ -9,13 +9,15 @@ export default function Footer() {
 
         <div className="flex items-center justify-between">
           {/* Copyright */}
-          <a
-            href="https://opendata.lk"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <div>
             <p className="text-primary/75 text-sm mb-0.5">
-              <span className="hover:text-accent">Open Data</span> ©{" "}
+              <a
+                href="https://opendata.lk"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span className="hover:text-accent">Open Data</span> ©{" "}
+              </a>
               {new Date().getFullYear()}. All rights reserved.
             </p>
             <p className="text-primary/75 text-xs mb-0.5">
@@ -29,7 +31,7 @@ export default function Footer() {
                 CC BY-NC-SA 4.0
               </a>
             </p>
-          </a>
+          </div>
 
           {/* Social Media Links */}
           <div className="flex items-center space-x-4">
@@ -68,6 +70,6 @@ export default function Footer() {
           </div>
         </div>
       </div>
-    </footer>
+    </footer >
   );
 }

--- a/src/pages/LandingPage/screens/LandingPage.jsx
+++ b/src/pages/LandingPage/screens/LandingPage.jsx
@@ -154,7 +154,7 @@ const LandingPage = () => {
                   onClick={() => navigate("/organization")}
                 >
                   <History className="w-6 h-6 mr-2" />
-                  <span className="text-smlg:text-md md:text-normal">
+                  <span className="text-sm lg:text-md md:text-normal">
                     Explore
                   </span>
                   <ChevronRight className="w-6 h-6" />


### PR DESCRIPTION
This PR closes: #93, #92

- This PR includes license update for the application footer
- `Doc` button removed