### PR TITLE
[BUG-FIX] Date range locking issue after using 'show me' action 

### DIFF
--- a/src/pages/HomePage/screens/HomePage.jsx
+++ b/src/pages/HomePage/screens/HomePage.jsx
@@ -51,6 +51,7 @@ export default function HomePage() {
   const handleDateRangeChange = useCallback((dateRange) => {
     const [startDate, endDate] = dateRange;
     setUserSelectedDateRange([startDate, endDate]);
+    setExternalDateRange([null, null]);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
this pr fixes the issue where the date range becomes locked after using the "Show me" button in the dataset view. The date range will now reset its "external focus" once it's been applied, allowing manual adjustments or use other navigation tools.