### PR TITLE
refactor: replace fetch API with axios (#157)

### DIFF
--- a/src/pages/DocsPage/screens/DocsPage.jsx
+++ b/src/pages/DocsPage/screens/DocsPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef } from "react";
 import { Menu, X } from "lucide-react";
+import axios from "axios";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { CopyButton } from "../components/CopyButton";
@@ -57,10 +58,9 @@ export default function DocsPage() {
     useEffect(() => {
         async function fetchDocFiles() {
             try {
-                const res = await fetch(
+                const { data } = await axios.get(
                     `https://api.github.com/repos/${GITHUB_USERNAME}/${REPO_NAME}/contents/docs?ref=${DOCS_BRANCH}&t=${Date.now()}`
                 );
-                const data = await res.json();
                 const mdFiles = Array.isArray(data)
                     ? data
                         .filter((f) => f.name.endsWith(".md"))
@@ -153,10 +153,10 @@ export default function DocsPage() {
 
         async function fetchMarkdown(fileName) {
             try {
-                const res = await fetch(
-                    `https://raw.githubusercontent.com/${GITHUB_USERNAME}/${REPO_NAME}/${DOCS_BRANCH}/docs/${fileName}?t=${Date.now()}`
+                const { data: md } = await axios.get(
+                    `https://raw.githubusercontent.com/${GITHUB_USERNAME}/${REPO_NAME}/${DOCS_BRANCH}/docs/${fileName}?t=${Date.now()}`,
+                    { responseType: "text" }
                 );
-                const md = await res.text();
                 if (cancelled) return;
                 setContent(md);
 

--- a/src/pages/OrganizationPage/components/PersonsTab.jsx
+++ b/src/pages/OrganizationPage/components/PersonsTab.jsx
@@ -28,12 +28,11 @@ const PersonsTab = ({ selectedDate }) => {
       try {
         setLoading(true);
 
-        const resPersonsResponse = await api.fetchActiveRelationsForMinistry(
+        const resPersons = await api.fetchActiveRelationsForMinistry(
           selectedDate,
           selectedMinistry,
           "AS_APPOINTED"
         );
-        const resPersons = await resPersonsResponse.json();
 
         const personMap = new Map();
         resPersons.forEach(

--- a/src/pages/OrganizationPage/components/PersonsTab.jsx
+++ b/src/pages/OrganizationPage/components/PersonsTab.jsx
@@ -32,7 +32,7 @@ const PersonsTab = ({ selectedDate }) => {
           selectedDate,
           selectedMinistry,
           "AS_APPOINTED"
-        );
+        ) || [];
 
         const personMap = new Map();
         resPersons.forEach(

--- a/src/pages/SplashPage/screens/dataLoadingAnimatedComponent.jsx
+++ b/src/pages/SplashPage/screens/dataLoadingAnimatedComponent.jsx
@@ -81,8 +81,7 @@ export default function DataLoadingAnimatedComponent({ mode }) {
 
   const fetchPersonData = async () => {
     try {
-      const personResponse = await api.fetchAllPersons();
-      const personList = await personResponse.json();
+      const personList = await api.fetchAllPersons();
       //dispatch(setAllPerson(personList.body));
       const personDict = listToDict(personList.body);
       dispatch(setAllPerson(personDict));
@@ -142,8 +141,7 @@ export default function DataLoadingAnimatedComponent({ mode }) {
 
   const fetchAllDepartmentData = async () => {
     try {
-      const response = await api.fetchAllDepartments();
-      const departmentList = await response.json();
+      const departmentList = await api.fetchAllDepartments();
       const departmentDict = listToDict(departmentList.body);
       dispatch(setAllDepartmentData(departmentDict));
     } catch (e) {
@@ -159,8 +157,8 @@ export default function DataLoadingAnimatedComponent({ mode }) {
         api.fetchAllCabinetMinistries(),
       ]);
 
-      const stateData = await stateRes.json();
-      const cabinetData = await cabinetRes.json();
+      const stateData = stateRes;
+      const cabinetData = cabinetRes;
 
       const stateDict = listToDict(stateData.body);
       const cabinetDict = listToDict(cabinetData.body);

--- a/src/services/services.jsx
+++ b/src/services/services.jsx
@@ -241,10 +241,7 @@ const fetchAllPersons = async () => {
     return data;
   } catch (error) {
     console.error("Error fetching person data from API:", error);
-    return {
-      dates: [],
-      allMinistryData: [],
-    };
+    return { body: [] };
   }
 };
 

--- a/src/services/services.jsx
+++ b/src/services/services.jsx
@@ -6,6 +6,7 @@ const apiUrl = window?.configs?.apiUrl ? window.configs.apiUrl : ""
 
 const GI_SERVICE_URL = "/v1/organisation";
 const GI_SERVICE_URL_PERSON = "/v1/person";
+const OPEN_GIN_REQUEST_CONFIG = { baseURL: "" };
 
 export const getActivePortfolioList = async ({ presidentId, date, signal }) => {
   const { data } = await axios.post(
@@ -80,42 +81,27 @@ export const getPersonHistory = async ({ personId, signal }) => {
 // Fetch initial gazette dates and all ministry protobuf data
 const fetchInitialGazetteData = async () => {
   try {
-    const response = await fetch(`${apiUrl}/v1/entities/search`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
+    const { data: result } = await axios.post(
+      `${apiUrl}/v1/entities/search`,
+      {
         kind: {
           major: "Document",
           minor: "extgztorg",
         },
-      }),
-    });
-
-    const responseForPerson = await fetch(`${apiUrl}/v1/entities/search`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
       },
-      body: JSON.stringify({
+      OPEN_GIN_REQUEST_CONFIG
+    );
+
+    const { data: resultForPerson } = await axios.post(
+      `${apiUrl}/v1/entities/search`,
+      {
         kind: {
           major: "Document",
           minor: "extgztperson",
         },
-      }),
-    });
-
-    if (!response.ok) {
-      throw new Error(`API error: ${response.statusText}`);
-    }
-
-    if (!responseForPerson.ok) {
-      throw new Error(`API error: ${responseForPerson.statusText}`);
-    }
-
-    const result = await response.json();
-    const resultForPerson = await responseForPerson.json();
+      },
+      OPEN_GIN_REQUEST_CONFIG
+    );
 
     const datesList1 = result.body.map((item) => {
       return {
@@ -156,18 +142,13 @@ const fetchInitialGazetteData = async () => {
 
 const fetchPresidentsData = async (governmentNodeId = "gov_01") => {
   try {
-    const response = await fetch(
+    const { data: jsonResponse } = await axios.post(
       `${apiUrl}/v1/entities/${governmentNodeId}/relations`,
+      { name: "AS_PRESIDENT" },
       {
-        method: "POST",
-        body: JSON.stringify({ name: "AS_PRESIDENT" }),
-        headers: {
-          "Content-Type": "application/json",
-        },
+        ...OPEN_GIN_REQUEST_CONFIG,
       }
     );
-
-    const jsonResponse = await response.json();
 
     return jsonResponse;
   } catch (e) {
@@ -182,29 +163,20 @@ const fetchActiveMinistries = async (
   selectedPresident
 ) => {
   try {
-    const response = await fetch(
+    const { data: activeMinistryRelations } = await axios.post(
       `${apiUrl}/v1/entities/${selectedPresident.id}/relations`,
       {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          relatedEntityId: "",
-          startTime: "",
-          endTime: "",
-          id: "",
-          name: "AS_MINISTER",
-          activeAt: `${selectedDate.date}T00:00:00Z`,
-        }),
+        relatedEntityId: "",
+        startTime: "",
+        endTime: "",
+        id: "",
+        name: "AS_MINISTER",
+        activeAt: `${selectedDate.date}T00:00:00Z`,
+      },
+      {
+        ...OPEN_GIN_REQUEST_CONFIG,
       }
     );
-
-    if (!response.ok) {
-      throw new Error(`API error: ${response.statusText}`);
-    }
-
-    const activeMinistryRelations = await response.json();
 
     // Extract relatedEntityId and startTime from each relation
     const activeMinistryInfo = activeMinistryRelations
@@ -255,24 +227,18 @@ const fetchActiveMinistries = async (
 
 const fetchAllPersons = async () => {
   try {
-    const response = await fetch(`${apiUrl}/v1/entities/search`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
+    const { data } = await axios.post(
+      `${apiUrl}/v1/entities/search`,
+      {
         kind: {
           major: "Person",
           minor: "citizen",
         },
-      }),
-    });
+      },
+      OPEN_GIN_REQUEST_CONFIG
+    );
 
-    if (!response.ok) {
-      throw new Error(`API error: ${response.statusText}`);
-    }
-
-    return response;
+    return data;
   } catch (error) {
     console.error("Error fetching person data from API:", error);
     return {
@@ -288,29 +254,22 @@ const fetchActiveRelationsForMinistry = async (
   relationType
 ) => {
   try {
-    const response = await fetch(
+    const { data } = await axios.post(
       `${apiUrl}/v1/entities/${ministryId}/relations`,
       {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          relatedEntityId: "",
-          startTime: "",
-          endTime: "",
-          id: "",
-          name: relationType,
-          activeAt: `${selectedDate}T00:00:00Z`,
-        }),
+        relatedEntityId: "",
+        startTime: "",
+        endTime: "",
+        id: "",
+        name: relationType,
+        activeAt: `${selectedDate}T00:00:00Z`,
+      },
+      {
+        ...OPEN_GIN_REQUEST_CONFIG,
       }
     );
 
-    if (!response.ok) {
-      throw new Error(`API error: ${response.statusText}`);
-    }
-
-    return response;
+    return data;
   } catch (error) {
     console.error("Error fetching active ministries:", error);
   }
@@ -318,68 +277,50 @@ const fetchActiveRelationsForMinistry = async (
 
 const fetchAllDepartments = async () => {
   // Fetch all department protobuf data
-  const response = await fetch(`${apiUrl}/v1/entities/search`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
+  const { data } = await axios.post(
+    `${apiUrl}/v1/entities/search`,
+    {
       kind: {
         major: "Organisation",
         minor: "department",
       },
-    }),
-  });
+    },
+    OPEN_GIN_REQUEST_CONFIG
+  );
 
-  if (!response.ok) {
-    throw new Error(`API error: ${response.statusText}`);
-  }
-
-  return response;
+  return data;
 };
 
 const fetchAllStateMinistries = async () => {
   // Fetch all state ministries protobuf data
-  const response = await fetch(`${apiUrl}/v1/entities/search`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
+  const { data } = await axios.post(
+    `${apiUrl}/v1/entities/search`,
+    {
       kind: {
         major: "Organisation",
         minor: "stateMinister",
       },
-    }),
-  });
+    },
+    OPEN_GIN_REQUEST_CONFIG
+  );
 
-  if (!response.ok) {
-    throw new Error(`API error: ${response.statusText}`);
-  }
-
-  return response;
+  return data;
 };
 
 const fetchAllCabinetMinistries = async () => {
   // Fetch all cabinet ministries protobuf data
-  const response = await fetch(`${apiUrl}/v1/entities/search`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
+  const { data } = await axios.post(
+    `${apiUrl}/v1/entities/search`,
+    {
       kind: {
         major: "Organisation",
         minor: "cabinetMinister",
       },
-    }),
-  });
+    },
+    OPEN_GIN_REQUEST_CONFIG
+  );
 
-  if (!response.ok) {
-    throw new Error(`API error: ${response.statusText}`);
-  }
-
-  return response;
+  return data;
 };
 
 const fetchAllRelationsForMinistry = async ({
@@ -392,29 +333,21 @@ const fetchAllRelationsForMinistry = async ({
   activeAt = "",
 }) => {
   try {
-    const response = await fetch(
+    const { data: json } = await axios.post(
       `${apiUrl}/v1/entities/${ministryId}/relations`,
       {
-        method: "POST",
-        body: JSON.stringify({
-          relatedEntityId: relatedEntityId,
-          startTime: startTime,
-          endTime: endTime,
-          id: id,
-          name: name,
-          activeAt: activeAt,
-        }),
-        headers: {
-          "Content-Type": "application/json",
-        },
+        relatedEntityId: relatedEntityId,
+        startTime: startTime,
+        endTime: endTime,
+        id: id,
+        name: name,
+        activeAt: activeAt,
+      },
+      {
+        ...OPEN_GIN_REQUEST_CONFIG,
       }
     );
 
-    if (!response.ok) {
-      throw new Error(`API error: ${response.statusText}`);
-    }
-
-    const json = await response.json();
     return json;
   } catch (error) {
     console.error(
@@ -454,19 +387,12 @@ const createDepartmentHistoryDictionary = async (allMinistryData) => {
 const chatbotApiCall = async (question, session_id) => {
   try {
     console.log(`this is the question ${question}`);
-    const response = await fetch(`/chat`, {
-      method: "POST",
-      body: JSON.stringify({ question, session_id }),
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
+    const { data: json } = await axios.post(
+      `/chat`,
+      { question, session_id },
+      OPEN_GIN_REQUEST_CONFIG
+    );
 
-    if (!response.ok) {
-      throw new Error(`API error: ${response.statusText}`);
-    }
-
-    const json = await response.json();
     return json;
   } catch (error) {
     console.error(`Chat Error`, error);
@@ -476,24 +402,17 @@ const chatbotApiCall = async (question, session_id) => {
 
 const getMinistriesByDepartment = async (departmentId) => {
   try {
-    const response = await fetch(
+    const { data } = await axios.post(
       `${apiUrl}/v1/entities/${departmentId}/relations`,
       {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          name: "AS_DEPARTMENT",
-        }),
+        name: "AS_DEPARTMENT",
+      },
+      {
+        ...OPEN_GIN_REQUEST_CONFIG,
       }
     );
 
-    if (!response.ok) {
-      throw new Error(`API error: ${response.statusText}`);
-    }
-
-    return response;
+    return data;
   } catch (error) {
     console.error("Error fetching past ministries for department:", error);
   }
@@ -501,24 +420,17 @@ const getMinistriesByDepartment = async (departmentId) => {
 
 const getDepartmentRenamedInfo = async (departmentId) => {
   try {
-    const response = await fetch(
+    const { data } = await axios.post(
       `${apiUrl}/v1/entities/${departmentId}/relations`,
       {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          name: "RENAMED_TO",
-        }),
+        name: "RENAMED_TO",
+      },
+      {
+        ...OPEN_GIN_REQUEST_CONFIG,
       }
     );
 
-    if (!response.ok) {
-      throw new Error(`API error: ${response.statusText}`);
-    }
-
-    return response;
+    return data;
   } catch (error) {
     console.error("Error fetching renamed department info:", error);
   }
@@ -526,24 +438,17 @@ const getDepartmentRenamedInfo = async (departmentId) => {
 
 const getMinistriesByPerson = async (personId) => {
   try {
-    const response = await fetch(
+    const { data } = await axios.post(
       `${apiUrl}/v1/entities/${personId}/relations`,
       {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          name: "AS_APPOINTED",
-        }),
+        name: "AS_APPOINTED",
+      },
+      {
+        ...OPEN_GIN_REQUEST_CONFIG,
       }
     );
 
-    if (!response.ok) {
-      throw new Error(`API error: ${response.statusText}`);
-    }
-
-    return response;
+    return data;
   } catch (error) {
     console.error("Error fetching renamed department info:", error);
   }


### PR DESCRIPTION
Closes #157.

Replaces the remaining direct `fetch()` calls with `axios` for consistency with the rest of the codebase.

- `services.jsx`: OpenGIN calls use `baseURL: ""` so they keep hitting `window.configs.apiUrl` (`/v1/...`)
- `DocsPage.jsx`: raw markdown fetch uses `responseType: "text"`
- callers updated to consume returned data directly (no more `.json()`)

Build passes (`npm run build`).

---
_Note: AI assistance was used for this change._