### PR TITLE
refactor: extract useCopyToClipboard hook to remove duplicated copy logic

### DIFF
--- a/src/components/ShareLinkButton.jsx
+++ b/src/components/ShareLinkButton.jsx
@@ -1,29 +1,15 @@
-import { useEffect, useState } from "react";
 import { Share2, Check } from "lucide-react";
+import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 
 const ShareLinkButton = () => {
-  const [copied, setCopied] = useState(false);
-
-  useEffect(() => {
-    if (copied) {
-      const timerId = setTimeout(() => {
-        setCopied(false);
-      }, 2000);
-
-      return () => clearTimeout(timerId);
-    }
-  }, [copied]);
+  const { copied, error, copy } = useCopyToClipboard(2000);
 
   const copyLink = () => {
     const currentUrl = window.location.href;
-    navigator.clipboard
-      .writeText(currentUrl)
-      .then(() => {
-        setCopied(true);
-      })
-      .catch(() => {
-        alert("Failed to copy link.");
-      });
+    copy(currentUrl);
+    if (error) {
+      alert("Failed to copy link.");
+    }
   };
 
   return (

--- a/src/components/ShareLinkButton.jsx
+++ b/src/components/ShareLinkButton.jsx
@@ -2,12 +2,12 @@ import { Share2, Check } from "lucide-react";
 import { useCopyToClipboard } from "../hooks/useCopyToClipboard";
 
 const ShareLinkButton = () => {
-  const { copied, error, copy } = useCopyToClipboard(2000);
+  const { copied, copy } = useCopyToClipboard(2000);
 
-  const copyLink = () => {
+  const copyLink = async () => {
     const currentUrl = window.location.href;
-    copy(currentUrl);
-    if (error) {
+    const success = await copy(currentUrl);
+    if (!success) {
       alert("Failed to copy link.");
     }
   };

--- a/src/hooks/useCopyToClipboard.js
+++ b/src/hooks/useCopyToClipboard.js
@@ -20,14 +20,13 @@ export const useCopyToClipboard = (resetDelay = 2000) => {
   }, []);
 
   useEffect(() => {
-    if (!copied) {
-      return undefined;
-    }
-    const timerId = setTimeout(() => {
-      setCopied(false);
-    }, resetDelay);
+    if (copied) {
+      const timerId = setTimeout(() => {
+        setCopied(false);
+      }, resetDelay);
 
-    return () => clearTimeout(timerId);
+      return () => clearTimeout(timerId);
+    }
   }, [copied, resetDelay]);
 
   const copy = useCallback(

--- a/src/hooks/useCopyToClipboard.js
+++ b/src/hooks/useCopyToClipboard.js
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Hook to copy text to the clipboard and track the "copied" state.
+ *
+ * Centralizes the copy-to-clipboard logic that was previously duplicated
+ * across CopyButton and ShareLinkButton, exposing a single reusable API
+ * with consistent error handling and auto-reset behavior.
+ *
+ * @param {number} resetDelay - How long (ms) the `copied` flag stays true before resetting. Defaults to 2000ms.
+ * @returns {{copied: boolean, copy: (text: string) => Promise<boolean>, reset: () => void}}
+ */
+export const useCopyToClipboard = (resetDelay = 2000) => {
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState(false);
+
+  const reset = useCallback(() => {
+    setCopied(false);
+    setError(false);
+  }, []);
+
+  useEffect(() => {
+    if (!copied) {
+      return undefined;
+    }
+    const timerId = setTimeout(() => {
+      setCopied(false);
+    }, resetDelay);
+
+    return () => clearTimeout(timerId);
+  }, [copied, resetDelay]);
+
+  const copy = useCallback(
+    async (text) => {
+      try {
+        await navigator.clipboard.writeText(text);
+        setCopied(true);
+        setError(false);
+        return true;
+      } catch (err) {
+        console.error("Failed to copy:", err);
+        setCopied(false);
+        setError(true);
+        return false;
+      }
+    },
+    []
+  );
+
+  return { copied, error, copy, reset };
+};
+
+export default useCopyToClipboard;

--- a/src/pages/DocsPage/components/CopyButton.jsx
+++ b/src/pages/DocsPage/components/CopyButton.jsx
@@ -1,17 +1,11 @@
 import { Link2 } from "lucide-react";
-import { useState } from "react";
+import { useCopyToClipboard } from "../../../hooks/useCopyToClipboard";
 
 export const CopyButton = ({ link }) => {
-    const [copied, setCopied] = useState(false);
+    const { copied, copy } = useCopyToClipboard(1500);
 
-    const handleCopy = async () => {
-        try {
-            await navigator.clipboard.writeText(link);
-            setCopied(true);
-            setTimeout(() => setCopied(false), 1500);
-        } catch (err) {
-            console.error("Failed to copy:", err);
-        }
+    const handleCopy = () => {
+        copy(link);
     };
 
     return (


### PR DESCRIPTION
## Description

The clipboard copy logic was duplicated between two components (`CopyButton` and `ShareLinkButton`), with inconsistent timeout durations and error handling between them. This PR extracts a single reusable hook so both components share one consistent implementation.

Closes #170

## Related Issue

Fixes #170 — the duplicated clipboard-copy logic described in the issue.

## Type of change

- [x] Refactor (no functional change)

## What changed

- **Added** `src/hooks/useCopyToClipboard.js` — a reusable hook that handles:
  - writing text to the clipboard via `navigator.clipboard`
  - tracking the `copied` state
  - auto-resetting after a configurable timeout (default 2000ms)
  - surfacing an `error` flag on failure
- **Updated** `src/pages/DocsPage/components/CopyButton.jsx` to use the hook (keeps its 1500ms reset)
- **Updated** `src/components/ShareLinkButton.jsx` to use the hook (keeps its 2000ms reset and the "Failed to copy link." alert on error)

## How Has This Been Tested?

- Verified the existing UI flow for both components (copy link in the docs citation tooltip and the header Share button) behaves identically before and after the change.
- `node --check` passed on the new hook file.
- This is a pure refactor with no behavioural change; no new dependencies added.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (JSDoc on the hook)
- [x] My changes generate no new warnings
- [x] I have read the **CONTRIBUTING** document