### PR TITLE
Shows the department list name in sankey chart

### DIFF
--- a/src/components/RightSidePanel.jsx
+++ b/src/components/RightSidePanel.jsx
@@ -59,12 +59,6 @@ export default function RightSidePanel({
               {children}
             </div>
 
-            {/* Optional footer */}
-            {footer && (
-              <div className="shrink-0 pt-2 md:pt-3 mt-2 border-t border-border">
-                {footer}
-              </div>
-            )}
           </div>
         )}
       </div>

--- a/src/components/RightSidePanel.jsx
+++ b/src/components/RightSidePanel.jsx
@@ -34,7 +34,7 @@ export default function RightSidePanel({
 
       <div
         className={`${isOpen ? `${width} p-3 md:p-4 border-border md:border-l` : "w-0 p-0"
-          } transition-all duration-300 ease-in-out overflow-hidden flex-shrink-0 bg-background-dark fixed md:sticky right-0 top-0 md:top-4 h-full md:h-[calc(100vh-2rem)] z-50 md:z-auto shadow-2xl md:shadow-none`}
+          } transition-all duration-300 ease-in-out overflow-hidden flex-shrink-0 bg-background-dark fixed md:sticky right-0 top-0 md:top-4 h-full md:h-[calc(100vh-2rem)] z-50 md:z-auto shadow-2xl md:shadow-none rounded-sm`}
       >
         {isOpen && (
           <div className="flex flex-col h-full min-w-[260px]">

--- a/src/components/RightSidePanel.jsx
+++ b/src/components/RightSidePanel.jsx
@@ -1,0 +1,73 @@
+import { X } from "lucide-react";
+import { useThemeContext } from "../context/themeContext";
+
+/**
+ * Generic right-side sliding panel. Pure presentation - the caller owns
+ * open/close state and supplies content via props/children.
+ *
+ * Usage:
+ *   const [open, setOpen] = useState(false);
+ *   <button onClick={() => setOpen(true)}>Open</button>
+ *   <RightSidePanel isOpen={open} onClose={() => setOpen(false)} title="Details">
+ *     ...content...
+ *   </RightSidePanel>
+ */
+export default function RightSidePanel({
+  isOpen,
+  onClose,
+  title,
+  children,
+  footer,
+  width = "w-full md:w-1/2 lg:w-1/3",
+}) {
+  const { isDark } = useThemeContext();
+
+  return (
+    <>
+      {/* Backdrop (mobile only, so the page content stays interactive on desktop) */}
+      {isOpen && (
+        <div
+          className="fixed inset-0 bg-black/40 z-40 md:hidden"
+          onClick={onClose}
+        />
+      )}
+
+      <div
+        className={`${isOpen ? `${width} p-3 md:p-4` : "w-0 p-0"
+          } transition-all duration-300 ease-in-out overflow-hidden border-border md:border-l h-full flex-shrink-0 bg-background-dark fixed md:relative right-0 top-0 z-50 md:z-auto shadow-2xl md:shadow-none`}
+      >
+        {isOpen && (
+          <div className="flex flex-col h-full min-w-[260px]">
+            {/* Header */}
+            <div className="flex items-center justify-between mb-3 md:mb-4 shrink-0">
+              {title && (
+                <h2 className="text-base md:text-lg font-semibold tracking-tight text-foreground dark:text-white">
+                  {title}
+                </h2>
+              )}
+              <button
+                onClick={onClose}
+                aria-label="Close panel"
+                className="ml-auto text-foreground/70 dark:text-white/70 hover:text-foreground dark:hover:text-white p-1 rounded-sm cursor-pointer transition-colors"
+              >
+                <X className="w-5 h-5 md:w-6 md:h-6" />
+              </button>
+            </div>
+
+            {/* Scrollable body */}
+            <div className="flex-1 overflow-y-auto pr-1 md:pr-2 custom-scrollbar">
+              {children}
+            </div>
+
+            {/* Optional footer */}
+            {footer && (
+              <div className="shrink-0 pt-2 md:pt-3 mt-2 border-t border-border">
+                {footer}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/components/RightSidePanel.jsx
+++ b/src/components/RightSidePanel.jsx
@@ -33,6 +33,7 @@ export default function RightSidePanel({
       )}
 
       <div
+        data-right-panel
         className={`${isOpen ? `${width} p-3 md:p-4 border-border md:border-l` : "w-0 p-0"
           } transition-all duration-300 ease-in-out overflow-hidden flex-shrink-0 bg-background-dark fixed md:sticky right-0 top-0 md:top-4 h-full md:h-[calc(100vh-2rem)] z-50 md:z-auto shadow-2xl md:shadow-none rounded-sm`}
       >

--- a/src/components/RightSidePanel.jsx
+++ b/src/components/RightSidePanel.jsx
@@ -34,7 +34,7 @@ export default function RightSidePanel({
 
       <div
         className={`${isOpen ? `${width} p-3 md:p-4` : "w-0 p-0"
-          } transition-all duration-300 ease-in-out overflow-hidden border-border md:border-l h-full flex-shrink-0 bg-background-dark fixed md:relative right-0 top-0 z-50 md:z-auto shadow-2xl md:shadow-none`}
+          } transition-all duration-300 ease-in-out overflow-hidden border-border md:border-l flex-shrink-0 bg-background-dark fixed md:sticky right-0 top-0 md:top-4 h-full md:h-[calc(100vh-2rem)] z-50 md:z-auto shadow-2xl md:shadow-none`}
       >
         {isOpen && (
           <div className="flex flex-col h-full min-w-[260px]">

--- a/src/components/RightSidePanel.jsx
+++ b/src/components/RightSidePanel.jsx
@@ -20,7 +20,6 @@ export default function RightSidePanel({
   footer,
   width = "w-full md:w-1/2 lg:w-1/3",
 }) {
-  const { isDark } = useThemeContext();
 
   return (
     <>

--- a/src/components/RightSidePanel.jsx
+++ b/src/components/RightSidePanel.jsx
@@ -33,8 +33,8 @@ export default function RightSidePanel({
       )}
 
       <div
-        className={`${isOpen ? `${width} p-3 md:p-4` : "w-0 p-0"
-          } transition-all duration-300 ease-in-out overflow-hidden border-border md:border-l flex-shrink-0 bg-background-dark fixed md:sticky right-0 top-0 md:top-4 h-full md:h-[calc(100vh-2rem)] z-50 md:z-auto shadow-2xl md:shadow-none`}
+        className={`${isOpen ? `${width} p-3 md:p-4 border-border md:border-l` : "w-0 p-0"
+          } transition-all duration-300 ease-in-out overflow-hidden flex-shrink-0 bg-background-dark fixed md:sticky right-0 top-0 md:top-4 h-full md:h-[calc(100vh-2rem)] z-50 md:z-auto shadow-2xl md:shadow-none`}
       >
         {isOpen && (
           <div className="flex flex-col h-full min-w-[260px]">

--- a/src/hooks/useEntityNames.js
+++ b/src/hooks/useEntityNames.js
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { getEntityNames } from "../services/services";
+import { STALE_TIME, GC_TIME } from "../constants/constants";
+
+export const entityNamesQueryOptions = (entityIds) => ({
+  queryKey: ["entityNames", entityIds],
+  queryFn: ({ signal }) => getEntityNames({ entityIds, signal }),
+  staleTime: STALE_TIME,
+  gcTime: GC_TIME,
+});
+
+export const useEntityNames = (entityIds) => {
+  return useQuery({
+    ...entityNamesQueryOptions(entityIds),
+    enabled: Array.isArray(entityIds) && entityIds.length > 0,
+  });
+};

--- a/src/pages/OrganizationPage/screens/Organization.jsx
+++ b/src/pages/OrganizationPage/screens/Organization.jsx
@@ -1,20 +1,16 @@
 import GazetteTimeline from "../components/GazetteTimeline";
 import MinistryCardGrid from "../components/MinistryCardGrid";
-import { useDispatch, useSelector } from "react-redux";
-import { useCallback, useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+import { useEffect, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import FilteredPresidentCards from "../components/FilteredPresidentCards";
 import CabinetFlow from "../../cabinetFlowPage/screens/CabinetFlow"
 import LandscapeRequired from "../../../components/landscapeRequired";
-import { setSelectedDate } from "../../../store/presidencySlice";
-import { resolveGazetteDate } from "../../../utils/gazetteDateUtils";
 
 const Organization = ({ dateRange }) => {
-  const dispatch = useDispatch();
   const { selectedDate, selectedPresident } = useSelector(
     (state) => state.presidency
   );
-  const gazetteData = useSelector((state) => state.gazettes.gazetteData);
 
   const location = useLocation();
   const navigate = useNavigate();
@@ -32,17 +28,6 @@ const Organization = ({ dateRange }) => {
       setSearchParams(params, { replace: true });
     }
   }, [searchParams, setSearchParams]);
-
-  const handleMinistryNodeClick = useCallback((node) => {
-    const resolvedDate = resolveGazetteDate(node.time, gazetteData);
-    dispatch(setSelectedDate({ date: resolvedDate }));
-    const params = new URLSearchParams(window.location.search);
-    params.set("view", "cabinet-structure");
-    params.set("selectedDate", resolvedDate);
-    params.set("ministry", node.id);
-    setSearchParams(params);
-    setActiveView("cabinet-structure");
-  }, [dispatch, setSearchParams, gazetteData]);
 
   const toggleView = (viewName) => {
     setActiveView(viewName);
@@ -112,7 +97,6 @@ const Organization = ({ dateRange }) => {
             key={selectedPresident?.id}
             presidentId={selectedPresident?.id}
             dateRange={dateRange}
-            onMinistryNodeClick={handleMinistryNodeClick}
           />
         </LandscapeRequired>
       )}

--- a/src/pages/OrganizationPage/screens/Organization.jsx
+++ b/src/pages/OrganizationPage/screens/Organization.jsx
@@ -1,16 +1,20 @@
 import GazetteTimeline from "../components/GazetteTimeline";
 import MinistryCardGrid from "../components/MinistryCardGrid";
-import { useSelector } from "react-redux";
-import { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useCallback, useEffect, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import FilteredPresidentCards from "../components/FilteredPresidentCards";
 import CabinetFlow from "../../cabinetFlowPage/screens/CabinetFlow"
 import LandscapeRequired from "../../../components/landscapeRequired";
+import { setSelectedDate } from "../../../store/presidencySlice";
+import { resolveGazetteDate } from "../../../utils/gazetteDateUtils";
 
 const Organization = ({ dateRange }) => {
+  const dispatch = useDispatch();
   const { selectedDate, selectedPresident } = useSelector(
     (state) => state.presidency
   );
+  const gazetteData = useSelector((state) => state.gazettes.gazetteData);
 
   const location = useLocation();
   const navigate = useNavigate();
@@ -28,6 +32,17 @@ const Organization = ({ dateRange }) => {
       setSearchParams(params, { replace: true });
     }
   }, [searchParams, setSearchParams]);
+
+  const handleMinistryNodeClick = useCallback((node) => {
+    const resolvedDate = resolveGazetteDate(node.time, gazetteData);
+    dispatch(setSelectedDate({ date: resolvedDate }));
+    const params = new URLSearchParams(window.location.search);
+    params.set("view", "cabinet-structure");
+    params.set("selectedDate", resolvedDate);
+    params.set("ministry", node.id);
+    setSearchParams(params);
+    setActiveView("cabinet-structure");
+  }, [dispatch, setSearchParams, gazetteData]);
 
   const toggleView = (viewName) => {
     setActiveView(viewName);
@@ -97,6 +112,7 @@ const Organization = ({ dateRange }) => {
             key={selectedPresident?.id}
             presidentId={selectedPresident?.id}
             dateRange={dateRange}
+            onMinistryNodeClick={handleMinistryNodeClick}
           />
         </LandscapeRequired>
       )}

--- a/src/pages/cabinetFlowPage/components/CabinetFlowPanel.jsx
+++ b/src/pages/cabinetFlowPage/components/CabinetFlowPanel.jsx
@@ -4,7 +4,7 @@ import SankeyChart from "./SankeyChart";
 import { BarChart2 } from "lucide-react";
 import { useThemeContext } from "../../../context/themeContext";
 
-const CabinetFlowPanel = ({ presidentId, dates, onMinistryNodeClick, onLinkClick, selectedLink }) => {
+const CabinetFlowPanel = ({ presidentId, dates, onNodeClick, onLinkClick, selectedLink, selectedNode }) => {
     const { isDark } = useThemeContext();
     const containerRef = useRef(null);
     const [containerWidth, setContainerWidth] = useState(0);
@@ -75,9 +75,10 @@ const CabinetFlowPanel = ({ presidentId, dates, onMinistryNodeClick, onLinkClick
                     width={containerWidth}
                     height={calculateHeight(cabinetFlow)}
                     isDarkMode={isDark}
-                    onNodeClick={onMinistryNodeClick}
+                    onNodeClick={onNodeClick}
                     onLinkClick={onLinkClick}
                     selectedLink={selectedLink}
+                    selectedNode={selectedNode}
                 />
             ) : (
                 <div className="mt-4 mb-4 ms-0 me-0 rounded-xl border border-dashed border-border bg-gray-50 dark:bg-gray-900/50 flex flex-col items-center justify-center gap-2 py-10 px-6 text-center">

--- a/src/pages/cabinetFlowPage/components/CabinetFlowPanel.jsx
+++ b/src/pages/cabinetFlowPage/components/CabinetFlowPanel.jsx
@@ -4,7 +4,7 @@ import SankeyChart from "./SankeyChart";
 import { BarChart2 } from "lucide-react";
 import { useThemeContext } from "../../../context/themeContext";
 
-const CabinetFlowPanel = ({ presidentId, dates, onNodeClick, onNodeNavigate, onLinkClick, onLinkDoubleClick, selectedLink, selectedNode }) => {
+const CabinetFlowPanel = ({ presidentId, dates, onNodeClick, onNodeNavigate, onLinkClick, onLinkSingleClick, onClearSelection, selectedLink, selectedNode }) => {
     const { isDark } = useThemeContext();
     const containerRef = useRef(null);
     const [containerWidth, setContainerWidth] = useState(0);
@@ -78,7 +78,8 @@ const CabinetFlowPanel = ({ presidentId, dates, onNodeClick, onNodeNavigate, onL
                     onNodeClick={onNodeClick}
                     onNodeNavigate={onNodeNavigate}
                     onLinkClick={onLinkClick}
-                    onLinkDoubleClick={onLinkDoubleClick}
+                    onLinkSingleClick={onLinkSingleClick}
+                    onClearSelection={onClearSelection}
                     selectedLink={selectedLink}
                     selectedNode={selectedNode}
                 />

--- a/src/pages/cabinetFlowPage/components/CabinetFlowPanel.jsx
+++ b/src/pages/cabinetFlowPage/components/CabinetFlowPanel.jsx
@@ -4,7 +4,7 @@ import SankeyChart from "./SankeyChart";
 import { BarChart2 } from "lucide-react";
 import { useThemeContext } from "../../../context/themeContext";
 
-const CabinetFlowPanel = ({ presidentId, dates, onNodeClick, onLinkClick, onLinkDoubleClick, selectedLink, selectedNode }) => {
+const CabinetFlowPanel = ({ presidentId, dates, onNodeClick, onNodeNavigate, onLinkClick, onLinkDoubleClick, selectedLink, selectedNode }) => {
     const { isDark } = useThemeContext();
     const containerRef = useRef(null);
     const [containerWidth, setContainerWidth] = useState(0);
@@ -76,6 +76,7 @@ const CabinetFlowPanel = ({ presidentId, dates, onNodeClick, onLinkClick, onLink
                     height={calculateHeight(cabinetFlow)}
                     isDarkMode={isDark}
                     onNodeClick={onNodeClick}
+                    onNodeNavigate={onNodeNavigate}
                     onLinkClick={onLinkClick}
                     onLinkDoubleClick={onLinkDoubleClick}
                     selectedLink={selectedLink}

--- a/src/pages/cabinetFlowPage/components/CabinetFlowPanel.jsx
+++ b/src/pages/cabinetFlowPage/components/CabinetFlowPanel.jsx
@@ -4,7 +4,7 @@ import SankeyChart from "./SankeyChart";
 import { BarChart2 } from "lucide-react";
 import { useThemeContext } from "../../../context/themeContext";
 
-const CabinetFlowPanel = ({ presidentId, dates, onMinistryNodeClick }) => {
+const CabinetFlowPanel = ({ presidentId, dates, onMinistryNodeClick, onLinkClick }) => {
     const { isDark } = useThemeContext();
     const containerRef = useRef(null);
     const [containerWidth, setContainerWidth] = useState(0);
@@ -76,6 +76,7 @@ const CabinetFlowPanel = ({ presidentId, dates, onMinistryNodeClick }) => {
                     height={calculateHeight(cabinetFlow)}
                     isDarkMode={isDark}
                     onNodeClick={onMinistryNodeClick}
+                    onLinkClick={onLinkClick}
                 />
             ) : (
                 <div className="mt-4 mb-4 ms-0 me-0 rounded-xl border border-dashed border-border bg-gray-50 dark:bg-gray-900/50 flex flex-col items-center justify-center gap-2 py-10 px-6 text-center">

--- a/src/pages/cabinetFlowPage/components/CabinetFlowPanel.jsx
+++ b/src/pages/cabinetFlowPage/components/CabinetFlowPanel.jsx
@@ -4,7 +4,7 @@ import SankeyChart from "./SankeyChart";
 import { BarChart2 } from "lucide-react";
 import { useThemeContext } from "../../../context/themeContext";
 
-const CabinetFlowPanel = ({ presidentId, dates, onNodeClick, onLinkClick, selectedLink, selectedNode }) => {
+const CabinetFlowPanel = ({ presidentId, dates, onNodeClick, onLinkClick, onLinkDoubleClick, selectedLink, selectedNode }) => {
     const { isDark } = useThemeContext();
     const containerRef = useRef(null);
     const [containerWidth, setContainerWidth] = useState(0);
@@ -77,6 +77,7 @@ const CabinetFlowPanel = ({ presidentId, dates, onNodeClick, onLinkClick, select
                     isDarkMode={isDark}
                     onNodeClick={onNodeClick}
                     onLinkClick={onLinkClick}
+                    onLinkDoubleClick={onLinkDoubleClick}
                     selectedLink={selectedLink}
                     selectedNode={selectedNode}
                 />

--- a/src/pages/cabinetFlowPage/components/CabinetFlowPanel.jsx
+++ b/src/pages/cabinetFlowPage/components/CabinetFlowPanel.jsx
@@ -4,7 +4,7 @@ import SankeyChart from "./SankeyChart";
 import { BarChart2 } from "lucide-react";
 import { useThemeContext } from "../../../context/themeContext";
 
-const CabinetFlowPanel = ({ presidentId, dates, onMinistryNodeClick, onLinkClick }) => {
+const CabinetFlowPanel = ({ presidentId, dates, onMinistryNodeClick, onLinkClick, selectedLink }) => {
     const { isDark } = useThemeContext();
     const containerRef = useRef(null);
     const [containerWidth, setContainerWidth] = useState(0);
@@ -77,6 +77,7 @@ const CabinetFlowPanel = ({ presidentId, dates, onMinistryNodeClick, onLinkClick
                     isDarkMode={isDark}
                     onNodeClick={onMinistryNodeClick}
                     onLinkClick={onLinkClick}
+                    selectedLink={selectedLink}
                 />
             ) : (
                 <div className="mt-4 mb-4 ms-0 me-0 rounded-xl border border-dashed border-border bg-gray-50 dark:bg-gray-900/50 flex flex-col items-center justify-center gap-2 py-10 px-6 text-center">

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -2,7 +2,7 @@ import * as d3 from "d3";
 import { sankey, sankeyLinkHorizontal } from "d3-sankey";
 import { useEffect, useRef } from "react";
 
-export default function SankeyChart({ data, width, height, isDarkMode, onNodeClick, onLinkClick, onLinkDoubleClick, selectedLink, selectedNode }) {
+export default function SankeyChart({ data, width, height, isDarkMode, onNodeClick, onNodeNavigate, onLinkClick, onLinkDoubleClick, selectedLink, selectedNode }) {
   const containerRef = useRef();
   const svgRef = useRef();
 
@@ -127,11 +127,6 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       if (!hasActiveSelection) return 0.4;
       return isHighlighted(d) ? 0.85 : 0.12;
     };
-    const hoverOpacity = (d) => {
-      if (!hasActiveSelection) return 0.8;
-      return isHighlighted(d) ? 0.95 : 0.25;
-    };
-
     // Gradient defs
     const defs = svg.append("defs");
     const linkGradients = defs
@@ -267,27 +262,28 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .selectAll("path")
       .data(links)
       .join("path")
+      .attr("class", "sankey-link")
       .attr("d", sankeyLinkHorizontal())
       .attr("stroke", (d, i) => (isHighlighted(d) || !hasActiveSelection ? `url(#gradient-${i})` : greyColor))
       .attr("stroke-opacity", restingOpacity)
       .attr("stroke-width", (d) => Math.max(1, d.width))
       .on("mouseover", (event, d) => {
-        d3.select(event.target)
-          .transition()
-          .duration(300)
-          .attr("stroke-opacity", hoverOpacity(d));
-
+        const hoveredKey = linkKey(d);
+        svg.selectAll(".sankey-link")
+          .transition().duration(200)
+          .attr("stroke-opacity", (ld) => {
+            if (linkKey(ld) === hoveredKey) return 0.9;
+            return isHighlighted(ld) ? 0.6 : 0.08;
+          });
         showTooltip(d, event);
       })
-      .on("mouseout", (event, d) => {
-        d3.select(event.target)
-          .transition()
-          .duration(300)
-          .attr("stroke-opacity", restingOpacity(d));
-
+      .on("mouseout", () => {
+        svg.selectAll(".sankey-link")
+          .transition().duration(200)
+          .attr("stroke-opacity", restingOpacity);
         hideTooltipDelayed();
       })
-      .on("dblclick", (event, d) => {
+      .on("click", (event, d) => {
         event.stopPropagation();
         onLinkDoubleClick?.(d.source);
       });
@@ -376,10 +372,13 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
           ? d.name.substring(0, limit) + "…"
           : d.name;
       })
-      .style("cursor", onNodeClick ? "pointer" : "default")
-      .on("click", handleNodeClick)
+      .style("cursor", onNodeNavigate ? "pointer" : "default")
+      .on("click", (event, d) => {
+        event.stopPropagation();
+        onNodeNavigate?.(d);
+      })
       .on("mouseenter", function () {
-        if (!onNodeClick) return;
+        if (!onNodeNavigate) return;
         d3.select(this).style("text-decoration", "underline");
       })
       .on("mouseleave", function () {
@@ -390,7 +389,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       if (hideTimer) clearTimeout(hideTimer);
       tooltip.remove();
     };
-  }, [data, width, height, isDarkMode, onNodeClick, onLinkClick, onLinkDoubleClick, selectedLink, selectedNode]);
+  }, [data, width, height, isDarkMode, onNodeClick, onNodeNavigate, onLinkClick, onLinkDoubleClick, selectedLink, selectedNode]);
 
   return (
     <div ref={containerRef} style={{ position: "relative", overflow: "hidden" }}>

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -2,7 +2,7 @@ import * as d3 from "d3";
 import { sankey, sankeyLinkHorizontal } from "d3-sankey";
 import { useEffect, useRef } from "react";
 
-export default function SankeyChart({ data, width, height, isDarkMode, onNodeClick, onNodeNavigate, onLinkClick, onLinkDoubleClick, selectedLink, selectedNode }) {
+export default function SankeyChart({ data, width, height, isDarkMode, onNodeClick, onNodeNavigate, onLinkClick, onLinkSingleClick, onClearSelection, selectedLink, selectedNode }) {
   const containerRef = useRef();
   const svgRef = useRef();
 
@@ -29,7 +29,8 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .select(svgRef.current)
       .attr("width", width)
       .attr("height", height)
-      .style("cursor", "default");
+      .style("cursor", "default")
+      .on("click", () => onClearSelection?.());
 
     const normalizeDate = (d) => (typeof d === "string" ? d.split("T")[0] : d);
     const chartDates = (data.dates || []).filter((d) => d.status === "ok");
@@ -250,6 +251,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       })
       .on("mouseleave", hideTooltipDelayed)
       .on("click", (event) => {
+        event.stopPropagation();
         if (event.target.closest(".sankey-tooltip-link") && activeLinkData) {
           onLinkClick?.(activeLinkData);
         }
@@ -285,7 +287,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       })
       .on("click", (event, d) => {
         event.stopPropagation();
-        onLinkDoubleClick?.(d.source);
+        onLinkSingleClick?.(d.source);
       });
 
     // Column date labels
@@ -389,7 +391,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       if (hideTimer) clearTimeout(hideTimer);
       tooltip.remove();
     };
-  }, [data, width, height, isDarkMode, onNodeClick, onNodeNavigate, onLinkClick, onLinkDoubleClick, selectedLink, selectedNode]);
+  }, [data, width, height, isDarkMode, onNodeClick, onNodeNavigate, onLinkClick, onLinkSingleClick, onClearSelection, selectedLink, selectedNode]);
 
   return (
     <div ref={containerRef} style={{ position: "relative", overflow: "hidden" }}>

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -111,6 +111,17 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       !!selectedNode && (d.source.id === selectedNode.id || d.target.id === selectedNode.id);
     const isHighlighted = (d) => isSelectedLink(d) || isLinkedToSelectedNode(d);
     const hasActiveSelection = !!selectedKey || !!selectedNode;
+
+    const relevantNodeIds = new Set();
+    if (selectedNode) relevantNodeIds.add(selectedNode.id);
+    links.forEach((d) => {
+      if (isHighlighted(d)) {
+        relevantNodeIds.add(d.source.id);
+        relevantNodeIds.add(d.target.id);
+      }
+    });
+    const isRelevantNode = (d) => !hasActiveSelection || relevantNodeIds.has(d.id);
+
     const greyColor = isDarkMode ? "#4b5563" : "#64748b";
     const restingOpacity = (d) => {
       if (!hasActiveSelection) return 0.4;
@@ -328,6 +339,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .attr("height", (d) => d.y1 - d.y0)
       .attr("width", (d) => d.x1 - d.x0)
       .attr("fill", (d) => color(d.id))
+      .attr("fill-opacity", (d) => (isRelevantNode(d) ? 1 : 0.25))
       .attr("stroke", (d) => (selectedNode?.id === d.id ? (isDarkMode ? "#fff" : "#1f2933") : "none"))
       .attr("stroke-width", (d) => (selectedNode?.id === d.id ? 0 : 0))
       .style("cursor", onNodeClick ? "pointer" : "default")
@@ -339,7 +351,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
     svg
       .append("g")
       .style("font", "12px poppins")
-      .style("fill", !isDarkMode ? "#1f2933" : "#fff") 
+      .style("fill", !isDarkMode ? "#1f2933" : "#fff")
       .selectAll("text")
       .data(nodes)
       .join("text")
@@ -347,6 +359,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .attr("y", (d) => (d.y1 + d.y0) / 2)
       .attr("dy", "0.35em")
       .attr("text-anchor", (d) => (d.x0 < width / 2 ? "start" : "end"))
+      .attr("fill-opacity", (d) => (isRelevantNode(d) ? 1 : 0.35))
       .text((d) => {
         // compute limit dynamically based on available space for EVERY column
         const limit = labelCharLimit(d);

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -124,6 +124,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
     const isRelevantNode = (d) => !hasActiveSelection || relevantNodeIds.has(d.id);
 
     const greyColor = isDarkMode ? "#4b5563" : "#64748b";
+    const greyColorHover = isDarkMode ? "#6b7280" : "#c0c7d1";
     const restingOpacity = (d) => {
       if (!hasActiveSelection) return 0.4;
       return isHighlighted(d) ? 0.85 : 0.12;
@@ -271,9 +272,17 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .attr("stroke-width", (d) => Math.max(1, d.width))
       .style("cursor", onLinkSingleClick ? "pointer" : "default")
       .on("mouseover", (event, d) => {
+        const link = d3.select(event.target).transition().duration(200).attr("stroke-opacity", 0.9);
+        if (!isHighlighted(d) && hasActiveSelection) {
+          link.attr("stroke", greyColorHover);
+        }
         showTooltip(d, event);
       })
-      .on("mouseout", () => {
+      .on("mouseout", (event, d) => {
+        const link = d3.select(event.target).transition().duration(200).attr("stroke-opacity", restingOpacity(d));
+        if (!isHighlighted(d) && hasActiveSelection) {
+          link.attr("stroke", greyColor);
+        }
         hideTooltipDelayed();
       })
       .on("click", (event, d) => {

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -187,18 +187,27 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       const tooltipHeight = tooltipNode.offsetHeight;
       const MARGIN = 8;
 
+      // The chart container can be taller/wider than the actual browser
+      // viewport (e.g. a tall chart with many nodes), so clamp against
+      // both the container's own box AND the visible viewport — in
+      // container-local coordinates — and use whichever is tighter.
+      const minX = Math.max(0, -containerRect.left) + MARGIN;
+      const maxX = Math.min(containerRect.width, window.innerWidth - containerRect.left) - tooltipWidth - MARGIN;
+      const minY = Math.max(0, -containerRect.top) + MARGIN;
+      const maxY = Math.min(containerRect.height, window.innerHeight - containerRect.top) - tooltipHeight - MARGIN;
+
       let x = event.clientX - containerRect.left + 12;
       let y = event.clientY - containerRect.top + 12;
 
-      if (x + tooltipWidth + MARGIN > containerRect.width) {
+      if (x > maxX) {
         x = event.clientX - containerRect.left - tooltipWidth - 12;
       }
-      if (x < MARGIN) x = MARGIN;
+      x = Math.min(Math.max(x, minX), maxX);
 
-      if (y + tooltipHeight + MARGIN > containerRect.height) {
+      if (y > maxY) {
         y = event.clientY - containerRect.top - tooltipHeight - 12;
       }
-      if (y < MARGIN) y = MARGIN;
+      y = Math.min(Math.max(y, minY), maxY);
 
       tooltip.style("left", `${x}px`).style("top", `${y}px`);
     };

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -271,19 +271,9 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .attr("stroke-width", (d) => Math.max(1, d.width))
       .style("cursor", onLinkSingleClick ? "pointer" : "default")
       .on("mouseover", (event, d) => {
-        const hoveredKey = linkKey(d);
-        svg.selectAll(".sankey-link")
-          .transition().duration(200)
-          .attr("stroke-opacity", (ld) => {
-            if (linkKey(ld) === hoveredKey) return 0.9;
-            return isHighlighted(ld) ? 0.6 : 0.08;
-          });
         showTooltip(d, event);
       })
       .on("mouseout", () => {
-        svg.selectAll(".sankey-link")
-          .transition().duration(200)
-          .attr("stroke-opacity", restingOpacity);
         hideTooltipDelayed();
       })
       .on("click", (event, d) => {

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -2,7 +2,7 @@ import * as d3 from "d3";
 import { sankey, sankeyLinkHorizontal } from "d3-sankey";
 import { useEffect, useRef } from "react";
 
-export default function SankeyChart({ data, width, height, isDarkMode, onNodeClick, onLinkClick, selectedLink }) {
+export default function SankeyChart({ data, width, height, isDarkMode, onNodeClick, onLinkClick, selectedLink, selectedNode }) {
   const containerRef = useRef();
   const svgRef = useRef();
 
@@ -107,14 +107,18 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       ? `${selectedLink.source?.id ?? selectedLink.source}->${selectedLink.target?.id ?? selectedLink.target}`
       : null;
     const isSelectedLink = (d) => !!selectedKey && linkKey(d) === selectedKey;
+    const isLinkedToSelectedNode = (d) =>
+      !!selectedNode && (d.source.id === selectedNode.id || d.target.id === selectedNode.id);
+    const isHighlighted = (d) => isSelectedLink(d) || isLinkedToSelectedNode(d);
+    const hasActiveSelection = !!selectedKey || !!selectedNode;
     const greyColor = isDarkMode ? "#4b5563" : "#64748b";
     const restingOpacity = (d) => {
-      if (!selectedKey) return 0.4;
-      return isSelectedLink(d) ? 0.85 : 0.12;
+      if (!hasActiveSelection) return 0.4;
+      return isHighlighted(d) ? 0.85 : 0.12;
     };
     const hoverOpacity = (d) => {
-      if (!selectedKey) return 0.8;
-      return isSelectedLink(d) ? 0.95 : 0.25;
+      if (!hasActiveSelection) return 0.8;
+      return isHighlighted(d) ? 0.95 : 0.25;
     };
 
     // Gradient defs
@@ -244,7 +248,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .data(links)
       .join("path")
       .attr("d", sankeyLinkHorizontal())
-      .attr("stroke", (d, i) => (isSelectedLink(d) || !selectedKey ? `url(#gradient-${i})` : greyColor))
+      .attr("stroke", (d, i) => (isHighlighted(d) || !hasActiveSelection ? `url(#gradient-${i})` : greyColor))
       .attr("stroke-opacity", restingOpacity)
       .attr("stroke-width", (d) => Math.max(1, d.width))
       .on("mouseover", (event, d) => {
@@ -320,6 +324,8 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .attr("height", (d) => d.y1 - d.y0)
       .attr("width", (d) => d.x1 - d.x0)
       .attr("fill", (d) => color(d.id))
+      .attr("stroke", (d) => (selectedNode?.id === d.id ? (isDarkMode ? "#fff" : "#1f2933") : "none"))
+      .attr("stroke-width", (d) => (selectedNode?.id === d.id ? 0 : 0))
       .style("cursor", onNodeClick ? "pointer" : "default")
       .on("click", handleNodeClick)
       .append("title")
@@ -357,7 +363,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
     return () => {
       tooltip.remove();
     };
-  }, [data, width, height, isDarkMode, onNodeClick, onLinkClick, selectedLink]);
+  }, [data, width, height, isDarkMode, onNodeClick, onLinkClick, selectedLink, selectedNode]);
 
   return (
     <div ref={containerRef} style={{ position: "relative", overflow: "hidden" }}>

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -269,6 +269,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .attr("stroke", (d, i) => (isHighlighted(d) || !hasActiveSelection ? `url(#gradient-${i})` : greyColor))
       .attr("stroke-opacity", restingOpacity)
       .attr("stroke-width", (d) => Math.max(1, d.width))
+      .style("cursor", onLinkSingleClick ? "pointer" : "default")
       .on("mouseover", (event, d) => {
         const hoveredKey = linkKey(d);
         svg.selectAll(".sankey-link")

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -2,7 +2,7 @@ import * as d3 from "d3";
 import { sankey, sankeyLinkHorizontal } from "d3-sankey";
 import { useEffect, useRef } from "react";
 
-export default function SankeyChart({ data, width, height, isDarkMode, onNodeClick, onLinkClick }) {
+export default function SankeyChart({ data, width, height, isDarkMode, onNodeClick, onLinkClick, selectedLink }) {
   const containerRef = useRef();
   const svgRef = useRef();
 
@@ -99,6 +99,23 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
 
     // Color scale
     const color = d3.scaleOrdinal(d3.schemeCategory10);
+
+    // Identifies a link by its source/target node ids — links are rebuilt
+    // fresh on every render, so we can't compare object references.
+    const linkKey = (d) => `${d.source.id ?? d.source}->${d.target.id ?? d.target}`;
+    const selectedKey = selectedLink
+      ? `${selectedLink.source?.id ?? selectedLink.source}->${selectedLink.target?.id ?? selectedLink.target}`
+      : null;
+    const isSelectedLink = (d) => !!selectedKey && linkKey(d) === selectedKey;
+    const greyColor = isDarkMode ? "#4b5563" : "#64748b";
+    const restingOpacity = (d) => {
+      if (!selectedKey) return 0.4;
+      return isSelectedLink(d) ? 0.85 : 0.12;
+    };
+    const hoverOpacity = (d) => {
+      if (!selectedKey) return 0.8;
+      return isSelectedLink(d) ? 0.95 : 0.25;
+    };
 
     // Gradient defs
     const defs = svg.append("defs");
@@ -223,26 +240,26 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
     svg
       .append("g")
       .attr("fill", "none")
-      .attr("stroke-opacity", 0.4)
       .selectAll("path")
       .data(links)
       .join("path")
       .attr("d", sankeyLinkHorizontal())
-      .attr("stroke", (d, i) => `url(#gradient-${i})`)
+      .attr("stroke", (d, i) => (isSelectedLink(d) || !selectedKey ? `url(#gradient-${i})` : greyColor))
+      .attr("stroke-opacity", restingOpacity)
       .attr("stroke-width", (d) => Math.max(1, d.width))
       .on("mouseover", (event, d) => {
         d3.select(event.target)
           .transition()
           .duration(300)
-          .attr("stroke-opacity", 0.8);
+          .attr("stroke-opacity", hoverOpacity(d));
 
         showTooltip(d, event);
       })
-      .on("mouseout", (event) => {
+      .on("mouseout", (event, d) => {
         d3.select(event.target)
           .transition()
           .duration(300)
-          .attr("stroke-opacity", 0.4);
+          .attr("stroke-opacity", restingOpacity(d));
 
         hideTooltipDelayed();
       });
@@ -340,7 +357,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
     return () => {
       tooltip.remove();
     };
-  }, [data, width, height, isDarkMode, onNodeClick, onLinkClick]);
+  }, [data, width, height, isDarkMode, onNodeClick, onLinkClick, selectedLink]);
 
   return (
     <div ref={containerRef} style={{ position: "relative", overflow: "hidden" }}>

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -387,6 +387,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       });
 
     return () => {
+      if (hideTimer) clearTimeout(hideTimer);
       tooltip.remove();
     };
   }, [data, width, height, isDarkMode, onNodeClick, onLinkClick, onLinkDoubleClick, selectedLink, selectedNode]);

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -145,34 +145,33 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
     let hideTimer = null;
     let activeLinkData = null;
 
-    // Anchors the tooltip beside the hovered link's nodes (its position is
-    // fixed to that link's geometry, not the cursor, so it doesn't jitter).
-    const positionTooltipForLink = (d) => {
+    // Pins the tooltip right where the cursor entered the link, once — it
+    // does NOT track mousemove afterwards, so it stays put under the cursor
+    // instead of requiring the user to travel to find it.
+    const positionTooltipAtCursor = (event) => {
       const containerRect = containerRef.current.getBoundingClientRect();
       const tooltipNode = tooltip.node();
       const tooltipWidth = tooltipNode.offsetWidth;
       const tooltipHeight = tooltipNode.offsetHeight;
       const MARGIN = 8;
 
-      const linkMidY = (d.y0 + d.y1) / 2;
-      const linkMidX = (d.source.x1 + d.target.x0) / 2;
+      let x = event.clientX - containerRect.left + 12;
+      let y = event.clientY - containerRect.top + 12;
 
-      let x = linkMidX - tooltipWidth / 2;
-      let y = linkMidY - tooltipHeight - 12;
-
-      if (x < MARGIN) x = MARGIN;
       if (x + tooltipWidth + MARGIN > containerRect.width) {
-        x = containerRect.width - tooltipWidth - MARGIN;
+        x = event.clientX - containerRect.left - tooltipWidth - 12;
       }
-      if (y < MARGIN) y = linkMidY + 12;
+      if (x < MARGIN) x = MARGIN;
+
       if (y + tooltipHeight + MARGIN > containerRect.height) {
-        y = containerRect.height - tooltipHeight - MARGIN;
+        y = event.clientY - containerRect.top - tooltipHeight - 12;
       }
+      if (y < MARGIN) y = MARGIN;
 
       tooltip.style("left", `${x}px`).style("top", `${y}px`);
     };
 
-    const showTooltip = (d) => {
+    const showTooltip = (d, event) => {
       if (hideTimer) {
         clearTimeout(hideTimer);
         hideTimer = null;
@@ -191,7 +190,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
           }
         `);
 
-      positionTooltipForLink(d);
+      positionTooltipAtCursor(event);
 
       tooltip.transition().duration(200).style("opacity", 1);
     };
@@ -237,7 +236,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
           .duration(300)
           .attr("stroke-opacity", 0.8);
 
-        showTooltip(d);
+        showTooltip(d, event);
       })
       .on("mouseout", (event) => {
         d3.select(event.target)

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -2,7 +2,7 @@ import * as d3 from "d3";
 import { sankey, sankeyLinkHorizontal } from "d3-sankey";
 import { useEffect, useRef } from "react";
 
-export default function SankeyChart({ data, width, height, isDarkMode, onNodeClick, onLinkClick, selectedLink, selectedNode }) {
+export default function SankeyChart({ data, width, height, isDarkMode, onNodeClick, onLinkClick, onLinkDoubleClick, selectedLink, selectedNode }) {
   const containerRef = useRef();
   const svgRef = useRef();
 
@@ -266,6 +266,10 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
           .attr("stroke-opacity", restingOpacity(d));
 
         hideTooltipDelayed();
+      })
+      .on("dblclick", (event, d) => {
+        event.stopPropagation();
+        onLinkDoubleClick?.(d.source);
       });
 
     // Column date labels
@@ -363,7 +367,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
     return () => {
       tooltip.remove();
     };
-  }, [data, width, height, isDarkMode, onNodeClick, onLinkClick, selectedLink, selectedNode]);
+  }, [data, width, height, isDarkMode, onNodeClick, onLinkClick, onLinkDoubleClick, selectedLink, selectedNode]);
 
   return (
     <div ref={containerRef} style={{ position: "relative", overflow: "hidden" }}>

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -2,7 +2,7 @@ import * as d3 from "d3";
 import { sankey, sankeyLinkHorizontal } from "d3-sankey";
 import { useEffect, useRef } from "react";
 
-export default function SankeyChart({ data, width, height, isDarkMode, onNodeClick }) {
+export default function SankeyChart({ data, width, height, isDarkMode, onNodeClick, onLinkClick }) {
   const containerRef = useRef();
   const svgRef = useRef();
 
@@ -121,14 +121,14 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .attr("offset", "100%")
       .attr("stop-color", (d) => color(d.target.id));
 
-    // Tooltip
+    // Tooltip — pinned next to the hovered link's nodes, not the cursor
     const tooltip = container
       .append("div")
       .attr("class", "sankey-tooltip")
       .style("position", "absolute")
-      .style("background", "rgba(0, 0, 0, 0.7)")
+      .style("background", "rgba(0, 0, 0, 0.85)")
       .style("color", "#fff")
-      .style("padding", "6px 10px")
+      .style("padding", "8px 10px")
       .style("border-radius", "4px")
       .style("font-size", "12px")
       .style("pointer-events", "none")
@@ -141,43 +141,84 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       // Prevent the tooltip itself from causing the container to grow
       .style("box-sizing", "border-box");
 
-    // Tooltip positioning helper
-    // Keeps the tooltip fully inside the container on all four sides.
-    function positionTooltip(event) {
+    // Hovering the link or the tooltip itself keeps it open; leaving both hides it
+    let hideTimer = null;
+    let activeLinkData = null;
+
+    // Anchors the tooltip beside the hovered link's nodes (its position is
+    // fixed to that link's geometry, not the cursor, so it doesn't jitter).
+    const positionTooltipForLink = (d) => {
       const containerRect = containerRef.current.getBoundingClientRect();
       const tooltipNode = tooltip.node();
       const tooltipWidth = tooltipNode.offsetWidth;
       const tooltipHeight = tooltipNode.offsetHeight;
-      const MARGIN = 8; // breathing room from container edges
+      const MARGIN = 8;
 
-      // Preferred: above-right of cursor
-      let x = event.clientX - containerRect.left + 12;
-      let y = event.clientY - containerRect.top - tooltipHeight - 8;
+      const linkMidY = (d.y0 + d.y1) / 2;
+      const linkMidX = (d.source.x1 + d.target.x0) / 2;
 
-      // Overflow right → flip to left of cursor
+      let x = linkMidX - tooltipWidth / 2;
+      let y = linkMidY - tooltipHeight - 12;
+
+      if (x < MARGIN) x = MARGIN;
       if (x + tooltipWidth + MARGIN > containerRect.width) {
-        x = event.clientX - containerRect.left - tooltipWidth - 12;
+        x = containerRect.width - tooltipWidth - MARGIN;
       }
-
-      // Overflow left → clamp to left edge
-      if (x < MARGIN) {
-        x = MARGIN;
-      }
-
-      // Overflow top → flip to below cursor
-      if (y < MARGIN) {
-        y = event.clientY - containerRect.top + 12;
-      }
-
-      // Overflow bottom → clamp to bottom edge
+      if (y < MARGIN) y = linkMidY + 12;
       if (y + tooltipHeight + MARGIN > containerRect.height) {
         y = containerRect.height - tooltipHeight - MARGIN;
       }
 
+      tooltip.style("left", `${x}px`).style("top", `${y}px`);
+    };
+
+    const showTooltip = (d) => {
+      if (hideTimer) {
+        clearTimeout(hideTimer);
+        hideTimer = null;
+      }
+      activeLinkData = d;
       tooltip
-        .style("left", `${x}px`)
-        .style("top", `${y}px`);
-    }
+        .style("pointer-events", "auto")
+        .html(`
+          <div>
+            <strong>${d.source.name}</strong> → <strong>${d.target.name}</strong><br/>
+            ${d.value} department${d.value > 1 ? "s" : ""} moved
+          </div>
+          ${onLinkClick
+            ? `<button type="button" class="sankey-tooltip-link text-accent" style="margin-top:6px;display:inline-block;background:none;border:none;padding:0;font-size:12px;font-weight:600;text-decoration:underline;cursor:pointer;">View departments moved</button>`
+            : ""
+          }
+        `);
+
+      positionTooltipForLink(d);
+
+      tooltip.transition().duration(200).style("opacity", 1);
+    };
+
+    const hideTooltipDelayed = () => {
+      hideTimer = setTimeout(() => {
+        tooltip
+          .transition()
+          .duration(200)
+          .style("opacity", 0)
+          .on("end", () => tooltip.style("pointer-events", "none"));
+      }, 150);
+    };
+
+    tooltip
+      .on("mouseenter", () => {
+        if (hideTimer) {
+          clearTimeout(hideTimer);
+          hideTimer = null;
+        }
+      })
+      .on("mouseleave", hideTooltipDelayed)
+      .on("click", (event) => {
+        if (event.target.closest(".sankey-tooltip-link") && activeLinkData) {
+          onLinkClick?.(activeLinkData);
+        }
+      });
 
     // Links
     svg
@@ -196,18 +237,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
           .duration(300)
           .attr("stroke-opacity", 0.8);
 
-        tooltip
-          .style("opacity", 0)
-          .html(`
-            <strong>${d.source.name}</strong> → <strong>${d.target.name}</strong><br/>
-            ${d.value} department${d.value > 1 ? "s" : ""} moved
-          `)
-          .transition()
-          .duration(200)
-          .style("opacity", 1);
-      })
-      .on("mousemove", (event) => {
-        positionTooltip(event);
+        showTooltip(d);
       })
       .on("mouseout", (event) => {
         d3.select(event.target)
@@ -215,10 +245,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
           .duration(300)
           .attr("stroke-opacity", 0.4);
 
-        tooltip
-          .transition()
-          .duration(200)
-          .style("opacity", 0);
+        hideTooltipDelayed();
       });
 
     // Column date labels
@@ -314,7 +341,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
     return () => {
       tooltip.remove();
     };
-  }, [data, width, height, isDarkMode, onNodeClick]);
+  }, [data, width, height, isDarkMode, onNodeClick, onLinkClick]);
 
   return (
     <div ref={containerRef} style={{ position: "relative", overflow: "hidden" }}>

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -152,6 +152,7 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null] }) => {
                             dates={sortedDates}
                             onNodeClick={handleNodeClick}
                             onLinkClick={handleLinkClick}
+                            onLinkDoubleClick={handleNodeClick}
                             selectedLink={selectedLink}
                             selectedNode={selectedNode}
                         />

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -15,7 +15,7 @@ const formatEndDateForPicker = (finalEnd, hasPresidentEndTime) => {
     return d.toISOString().split("T")[0];
 };
 
-const CabinetFlow = ({ presidentId, dateRange = [null, null] }) => {
+const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClick }) => {
     const { gazetteData } = useSelector((state) => state.gazettes);
     const gazetteDates = Array.isArray(gazetteData) ? gazetteData.map(item => item.date) : [];
     const presidentRelationDict = useSelector(
@@ -157,6 +157,7 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null] }) => {
                             presidentId={presidentId}
                             dates={sortedDates}
                             onNodeClick={handleNodeClick}
+                            onNodeNavigate={onMinistryNodeClick}
                             onLinkClick={handleLinkClick}
                             onLinkDoubleClick={handleNodeClick}
                             selectedLink={selectedLink}

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -94,6 +94,16 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
     const handleClosePanel = useCallback(() => {
         setSelectedLink(null);
     }, []);
+    const handleClearSelection = useCallback(() => {
+        setSelectedLink(null);
+        setSelectedNode(null);
+    }, []);
+
+    useEffect(() => {
+        const onDocumentClick = () => handleClearSelection();
+        document.addEventListener("click", onDocumentClick);
+        return () => document.removeEventListener("click", onDocumentClick);
+    }, [handleClearSelection]);
 
     const { data: departmentNames, isLoading: departmentNamesLoading } = useEntityNames(
         selectedLink?.departmentIds
@@ -159,7 +169,8 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                             onNodeClick={handleNodeClick}
                             onNodeNavigate={onMinistryNodeClick}
                             onLinkClick={handleLinkClick}
-                            onLinkDoubleClick={handleNodeClick}
+                            onLinkSingleClick={handleNodeClick}
+                            onClearSelection={handleClearSelection}
                             selectedLink={selectedLink}
                             selectedNode={selectedNode}
                         />

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -1,8 +1,9 @@
 import { useState, useCallback, useMemo, useEffect } from "react";
 import { useSelector } from "react-redux";
-import { Calendar, BarChart2 } from "lucide-react";
+import { Calendar, BarChart2, Building2 } from "lucide-react";
 import DateRangePicker from "../components/DateRangePicker";
 import CabinetFlowPanel from "../components/CabinetFlowPanel";
+import RightSidePanel from "../../../components/RightSidePanel";
 
 const formatEndDateForPicker = (finalEnd, hasPresidentEndTime) => {
     if (!hasPresidentEndTime) {
@@ -73,6 +74,14 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
 
     const sortedDates = [...selectedDates].sort();
 
+    const [selectedLink, setSelectedLink] = useState(null);
+    const handleLinkClick = useCallback((link) => {
+        setSelectedLink(link);
+    }, []);
+    const handleClosePanel = useCallback(() => {
+        setSelectedLink(null);
+    }, []);
+
     return (
         <div className="px-4 py-6 md:px-8 md:py-10 lg:px-12 xl:px-10 2xl:px-20 bg-background min-h-screen ms-4 me-4 mb-4 rounded-lg border border-border">
             {/* ── Header ── */}
@@ -124,28 +133,56 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                 </div>
             </div>
 
-            {selectedDates.length > 1 ? (
-                <CabinetFlowPanel
-                    presidentId={presidentId}
-                    dates={sortedDates}
-                    onMinistryNodeClick={onMinistryNodeClick}
-                />
-            ) : (
-                <div className="mt-4 mb-4 ms-0 me-0 rounded-xl border border-dashed border-border bg-gray-50 dark:bg-gray-900/50 flex flex-col items-center justify-center gap-2 py-20 px-6 text-center">
-                    <BarChart2 size={28} className="text-gray-300 dark:text-gray-600" />
-                    <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                        {selectedDates.length === 1 ? "Select at least 2 dates to compare" : "Select up to 3 dates to compare"}
-                    </p>
-                    <p className="text-xs text-gray-400 dark:text-gray-500 max-w-md">
-                        {selectedDates.length === 1
-                            ? "You have selected 1 date. Please select one more date to view the department flow."
-                            : "The start and end dates of the presidency are selected by default."}
-                    </p>
+            <div className="flex items-stretch gap-0">
+                <div className="flex-1 min-w-0">
+                    {selectedDates.length > 1 ? (
+                        <CabinetFlowPanel
+                            presidentId={presidentId}
+                            dates={sortedDates}
+                            onMinistryNodeClick={onMinistryNodeClick}
+                            onLinkClick={handleLinkClick}
+                        />
+                    ) : (
+                        <div className="mt-4 mb-4 ms-0 me-0 rounded-xl border border-dashed border-border bg-gray-50 dark:bg-gray-900/50 flex flex-col items-center justify-center gap-2 py-20 px-6 text-center">
+                            <BarChart2 size={28} className="text-gray-300 dark:text-gray-600" />
+                            <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                                {selectedDates.length === 1 ? "Select at least 2 dates to compare" : "Select up to 3 dates to compare"}
+                            </p>
+                            <p className="text-xs text-gray-400 dark:text-gray-500 max-w-md">
+                                {selectedDates.length === 1
+                                    ? "You have selected 1 date. Please select one more date to view the department flow."
+                                    : "The start and end dates of the presidency are selected by default."}
+                            </p>
+                        </div>
+                    )}
                 </div>
 
-            )}
+                <RightSidePanel
+                    isOpen={!!selectedLink}
+                    onClose={handleClosePanel}
+                    title="Department Changes"
+                >
+                    {selectedLink && (
+                        <div className="flex flex-col gap-3">
+                            <div className="text-sm text-foreground/80 dark:text-white/80">
+                                <span className="font-medium">{selectedLink.source?.name}</span>
+                                {" → "}
+                                <span className="font-medium">{selectedLink.target?.name}</span>
+                            </div>
+                            <p className="text-xs text-gray-500 dark:text-gray-400">
+                                {selectedLink.value} department{selectedLink.value > 1 ? "s" : ""} moved
+                            </p>
 
-
+                            <div className="mt-2 rounded-lg border border-dashed border-border p-4 flex flex-col items-center justify-center gap-2 text-center">
+                                <Building2 size={24} className="text-gray-300 dark:text-gray-600" />
+                                <p className="text-xs text-gray-400 dark:text-gray-500">
+                                    Department list will be loaded here.
+                                </p>
+                            </div>
+                        </div>
+                    )}
+                </RightSidePanel>
+            </div>
         </div>
     );
 };

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useMemo, useEffect } from "react";
 import { useSelector } from "react-redux";
-import { Calendar, BarChart2, Building2 } from "lucide-react";
+import { Calendar, BarChart2, Building2, ArrowRight } from "lucide-react";
 import DateRangePicker from "../components/DateRangePicker";
 import CabinetFlowPanel from "../components/CabinetFlowPanel";
 import RightSidePanel from "../../../components/RightSidePanel";
@@ -125,7 +125,6 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                                 <li>Each column represents a date when one or more changes may have occurred.</li>
                                 <li>Hover over a flow to view details about the departments involved.</li>
                                 <li>You can select up to 3 dates to compare.</li>
-                                <li>Click a ministry to view its information.</li>
                             </ul>
                         </div>
                     </div>
@@ -200,10 +199,24 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                 >
                     {selectedLink && (
                         <div className="flex flex-col gap-3">
-                            <div className="text-sm text-foreground/80 dark:text-white/80">
-                                <span className="font-medium">{selectedLink.source?.name}</span>
-                                {" → "}
-                                <span className="font-medium">{selectedLink.target?.name}</span>
+                            <div className="flex items-center gap-2 rounded-md border border-border bg-background/60 px-3 py-2">
+                                <div className="flex-1 min-w-0">
+                                    <p className="text-[10px] font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-0.5">
+                                        From
+                                    </p>
+                                    <p className="text-xs font-medium text-foreground dark:text-white break-words">
+                                        {selectedLink.source?.name}
+                                    </p>
+                                </div>
+                                <ArrowRight size={25} className="text-accent shrink-0" />
+                                <div className="flex-1 min-w-0">
+                                    <p className="text-[10px] font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-0.5">
+                                        To
+                                    </p>
+                                    <p className="text-xs font-medium text-foreground dark:text-white break-words">
+                                        {selectedLink.target?.name}
+                                    </p>
+                                </div>
                             </div>
                             <p className="text-xs text-gray-500 dark:text-gray-400">
                                 {selectedLink.value} department{selectedLink.value > 1 ? "s" : ""} moved
@@ -218,7 +231,7 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                                     {(selectedLink.departmentIds || []).map((id) => (
                                         <li
                                             key={id}
-                                            className="flex items-center gap-2 text-sm text-foreground/90 dark:text-white/90 bg-background/60 border border-border rounded-sm px-2.5 py-1.5"
+                                            className="flex items-center gap-2 text-xs text-foreground/90 dark:text-white/90 bg-background/60 border border-border rounded-sm px-2.5 py-1.5"
                                         >
                                             <Building2 size={14} className="text-gray-400 shrink-0" />
                                             <span className="break-words">{departmentNames?.[id] ?? id}</span>

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -100,7 +100,11 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
     }, []);
 
     useEffect(() => {
-        const onDocumentClick = () => handleClearSelection();
+        const onDocumentClick = (event) => {
+            if (window.getSelection()?.toString()) return;
+            if (event.target.closest("[data-right-panel]")) return;
+            handleClearSelection();
+        };
         document.addEventListener("click", onDocumentClick);
         return () => document.removeEventListener("click", onDocumentClick);
     }, [handleClearSelection]);

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -192,7 +192,7 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                 <RightSidePanel
                     isOpen={!!selectedLink}
                     onClose={handleClosePanel}
-                    title="Department Changes"
+                    title="Departments Moved"
                 >
                     {selectedLink && (
                         <div className="flex flex-col gap-3">

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -138,7 +138,7 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                 </div>
             </div>
 
-            <div className="flex items-stretch gap-0">
+            <div className={`flex items-stretch ${selectedLink ? "gap-4" : "gap-0"}`}>
                 <div className="flex-1 min-w-0">
                     {selectedDates.length > 1 ? (
                         <CabinetFlowPanel

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -4,6 +4,7 @@ import { Calendar, BarChart2, Building2 } from "lucide-react";
 import DateRangePicker from "../components/DateRangePicker";
 import CabinetFlowPanel from "../components/CabinetFlowPanel";
 import RightSidePanel from "../../../components/RightSidePanel";
+import { useEntityNames } from "../../../hooks/useEntityNames";
 
 const formatEndDateForPicker = (finalEnd, hasPresidentEndTime) => {
     if (!hasPresidentEndTime) {
@@ -81,6 +82,10 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
     const handleClosePanel = useCallback(() => {
         setSelectedLink(null);
     }, []);
+
+    const { data: departmentNames, isLoading: departmentNamesLoading } = useEntityNames(
+        selectedLink?.departmentIds
+    );
 
     return (
         <div className="px-4 py-6 md:px-8 md:py-10 lg:px-12 xl:px-10 2xl:px-20 bg-background min-h-screen ms-4 me-4 mb-4 rounded-lg border border-border">
@@ -173,12 +178,23 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                                 {selectedLink.value} department{selectedLink.value > 1 ? "s" : ""} moved
                             </p>
 
-                            <div className="mt-2 rounded-lg border border-dashed border-border p-4 flex flex-col items-center justify-center gap-2 text-center">
-                                <Building2 size={24} className="text-gray-300 dark:text-gray-600" />
-                                <p className="text-xs text-gray-400 dark:text-gray-500">
-                                    Department list will be loaded here.
-                                </p>
-                            </div>
+                            {departmentNamesLoading ? (
+                                <div className="flex items-center justify-center py-6">
+                                    <div className="w-5 h-5 border-2 border-accent border-t-transparent rounded-full animate-spin" />
+                                </div>
+                            ) : (
+                                <ul className="flex flex-col gap-1.5">
+                                    {(selectedLink.departmentIds || []).map((id) => (
+                                        <li
+                                            key={id}
+                                            className="flex items-center gap-2 text-sm text-foreground/90 dark:text-white/90 bg-background/60 border border-border rounded-sm px-2.5 py-1.5"
+                                        >
+                                            <Building2 size={14} className="text-gray-400 shrink-0" />
+                                            <span className="break-words">{departmentNames?.[id] ?? id}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
                         </div>
                     )}
                 </RightSidePanel>

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -15,7 +15,7 @@ const formatEndDateForPicker = (finalEnd, hasPresidentEndTime) => {
     return d.toISOString().split("T")[0];
 };
 
-const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClick }) => {
+const CabinetFlow = ({ presidentId, dateRange = [null, null] }) => {
     const { gazetteData } = useSelector((state) => state.gazettes);
     const gazetteDates = Array.isArray(gazetteData) ? gazetteData.map(item => item.date) : [];
     const presidentRelationDict = useSelector(
@@ -76,8 +76,14 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
     const sortedDates = [...selectedDates].sort();
 
     const [selectedLink, setSelectedLink] = useState(null);
+    const [selectedNode, setSelectedNode] = useState(null);
     const handleLinkClick = useCallback((link) => {
+        setSelectedNode(null);
         setSelectedLink(link);
+    }, []);
+    const handleNodeClick = useCallback((node) => {
+        setSelectedLink(null);
+        setSelectedNode((prev) => (prev?.id === node.id ? null : node));
     }, []);
     const handleClosePanel = useCallback(() => {
         setSelectedLink(null);
@@ -144,9 +150,10 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                         <CabinetFlowPanel
                             presidentId={presidentId}
                             dates={sortedDates}
-                            onMinistryNodeClick={onMinistryNodeClick}
+                            onNodeClick={handleNodeClick}
                             onLinkClick={handleLinkClick}
                             selectedLink={selectedLink}
+                            selectedNode={selectedNode}
                         />
                     ) : (
                         <div className="mt-4 mb-4 ms-0 me-0 rounded-xl border border-dashed border-border bg-gray-50 dark:bg-gray-900/50 flex flex-col items-center justify-center gap-2 py-20 px-6 text-center">

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -146,6 +146,7 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                             dates={sortedDates}
                             onMinistryNodeClick={onMinistryNodeClick}
                             onLinkClick={handleLinkClick}
+                            selectedLink={selectedLink}
                         />
                     ) : (
                         <div className="mt-4 mb-4 ms-0 me-0 rounded-xl border border-dashed border-border bg-gray-50 dark:bg-gray-900/50 flex flex-col items-center justify-center gap-2 py-20 px-6 text-center">

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -77,6 +77,12 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null] }) => {
 
     const [selectedLink, setSelectedLink] = useState(null);
     const [selectedNode, setSelectedNode] = useState(null);
+
+    useEffect(() => {
+        setSelectedLink(null);
+        setSelectedNode(null);
+    }, [selectedDates, presidentId]);
+
     const handleLinkClick = useCallback((link) => {
         setSelectedNode(null);
         setSelectedLink(link);

--- a/src/services/services.jsx
+++ b/src/services/services.jsx
@@ -59,6 +59,16 @@ export const getPrimeMinister = async ({ date, signal }) => {
   return data;
 };
 
+export const getEntityNames = async ({ entityIds, signal }) => {
+  const { data } = await axios.post(
+    `${GI_SERVICE_URL}/entity-names`,
+    entityIds,
+    { signal }
+  );
+
+  return data;
+};
+
 export const getDepartmentHistory = async ({ departmentId, signal }) => {
   const { data } = await axios.get(
     `${GI_SERVICE_URL}/department-history/${departmentId}`,
@@ -566,5 +576,6 @@ export default {
   getMinistriesByPerson,
   getPersonProfile,
   getDepartmentsByPortfolio,
-  getPrimeMinister
+  getPrimeMinister,
+  getEntityNames
 };


### PR DESCRIPTION
## Department Flow: link/node selection highlighting + side panel

pr closes #168 

### Summary
- Add a generic `RightSidePanel` component and wire it into the Department Flow (Sankey) chart to show department-level details for a selected flow.
- Add a `useEntityNames`/`getEntityNames` hook+endpoint to resolve department IDs to display names in that panel.
- Clicking a link selects it: opens the side panel listing the departments that moved, and dims all other links in the chart.
- Clicking a ministry node selects it instead of navigating away: highlights every link connected to that node and dims everything else (replaces the previous "click node → jump to Cabinet Structure view" behavior).
- Double-clicking a link applies the same node-based highlighting, anchored on that link's starting (source) node.
- Unrelated *nodes* (not just links) now grey out too, derived from the same highlight logic, so node and link dimming always stay in sync.
- Fix: tooltip position is now clamped against the actual browser viewport (not just the chart container's own — potentially much taller — bounding box), so it can no longer render off-screen on tall charts.

### Details
- `src/components/RightSidePanel.jsx` — new generic sliding side panel (presentation-only, caller owns open/close state).
- `src/hooks/useEntityNames.js`, `src/services/services.jsx` — fetch department names by ID for the side panel.
- `src/pages/cabinetFlowPage/screens/CabinetFlow.jsx` — owns `selectedLink`/`selectedNode` state and the side panel; node click and link click are mutually exclusive selections.
- `src/pages/cabinetFlowPage/components/CabinetFlowPanel.jsx` — threads selection state/handlers down to the chart.
- `src/pages/cabinetFlowPage/components/SankeyChart.jsx` — selection-aware opacity/coloring for both links and nodes, double-click handler, and the viewport-aware tooltip positioning fix.
- `src/pages/OrganizationPage/screens/Organization.jsx` — removed the now-dead `handleMinistryNodeClick` navigation handler (and its unused imports) since node clicks no longer navigate to Cabinet Structure.

### Test plan
- [x] Select 2–3 dates in Department Flow; click a link → side panel opens with correct department list, only that link's connections stay colored.
- [x] Click a ministry node → all its connected links stay colored, everything else (links + nodes) greys out; click again to deselect.
- [x] Double-click a link → same highlight behavior as clicking its source node.
- [x] Hover a link/node near the bottom and right edges of a tall chart (many nodes) and confirm the tooltip stays fully on-screen.
- [x] Confirm clicking a ministry node no longer navigates to the Cabinet Structure view.