### PR TITLE
fix: correct Sankey chart column layout, selection highlighting, and date picker limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -105,6 +105,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -421,6 +422,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -464,6 +466,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1335,6 +1338,7 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.2.tgz",
       "integrity": "sha512-qXvbnawQhqUVfH1LMgMaiytP+ZpGoYhnGl7yYq2x57GYzcFL/iPzSZ3L30tlbwEjSVKNYcbiKO8tANR1tadjUg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.3",
         "@mui/core-downloads-tracker": "^7.3.2",
@@ -1445,6 +1449,7 @@
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.2.tgz",
       "integrity": "sha512-9d8JEvZW+H6cVkaZ+FK56R53vkJe3HsTpcjMUtH8v1xK6Y1TjzHdZ7Jck02mGXJsE6MQGWVs3ogRHTQmS9Q/rA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.3",
         "@mui/private-theming": "^7.3.2",
@@ -3062,6 +3067,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3072,6 +3078,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3483,6 +3490,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -3648,6 +3656,7 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
       "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -4238,6 +4247,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4390,6 +4400,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -4399,7 +4410,8 @@
       "version": "1.11.18",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
       "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -4863,6 +4875,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.36.0.tgz",
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5575,7 +5588,8 @@
       "version": "12.4.0",
       "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-12.4.0.tgz",
       "integrity": "sha512-o6UxxfChSUrvrZUbWrAuqL1HO/+exhAUPcZY6nnqLsadZQlnP16d082sg7DnXKZCk1gtfkyfkp6g3qkIZ9miZg==",
-      "license": "https://www.highcharts.com/license"
+      "license": "https://www.highcharts.com/license",
+      "peer": true
     },
     "node_modules/highcharts-react-official": {
       "version": "3.2.2",
@@ -6232,6 +6246,7 @@
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.0.0.tgz",
       "integrity": "sha512-w12U97Z6edKd2tXDn3LzTLg7C7QLJlx0BPfM3ecjK2BckUl9/81vZ+r5gK4/3KQdhAcEZhENUxRhtgYBj75MqQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "fast-png": "^6.2.0",
@@ -9547,6 +9562,7 @@
       "version": "4.0.3",
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10039,6 +10055,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10073,6 +10090,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10122,7 +10140,8 @@
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
       "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-kapsule": {
       "version": "2.5.7",
@@ -10181,6 +10200,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -10420,7 +10440,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -11732,6 +11753,7 @@
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
       "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
@@ -11760,7 +11782,8 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
       "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -11823,7 +11846,8 @@
       "version": "0.180.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
       "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/three-forcegraph": {
       "version": "1.43.0",
@@ -11930,6 +11954,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12422,6 +12447,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -12513,6 +12539,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,7 @@ const AppRoutes = () => {
 
   return (
     <Routes>
-      <Route path="/" element={<Navigate to="/organization?view=cabinet-structure" replace />} />
+      <Route path="/" element={<Navigate to="/executive-branch?view=cabinet-structure" replace />} />
       <Route path="/person-profile/:personId" element={<DataLoadingAnimatedComponent mode="person-profile" />} />
       <Route path="/department-profile/:departmentId" element={<DataLoadingAnimatedComponent mode="department-profile" />} />
       <Route path="/docs" element={<DocsPage />} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,7 @@ const AppRoutes = () => {
 
   return (
     <Routes>
-      <Route path="/" element={<Navigate to="/executive-branch?view=cabinet-structure" replace />} />
+      <Route path="/" element={<Navigate to="/executive-branch?view=structure" replace />} />
       <Route path="/person-profile/:personId" element={<DataLoadingAnimatedComponent mode="person-profile" />} />
       <Route path="/department-profile/:departmentId" element={<DataLoadingAnimatedComponent mode="department-profile" />} />
       <Route path="/docs" element={<DocsPage />} />

--- a/src/components/PersonAvatar.jsx
+++ b/src/components/PersonAvatar.jsx
@@ -1,11 +1,15 @@
 import { User2 } from "lucide-react";
+import { useState } from "react";
 
 export default function PersonAvatar({ isOnline, imageUrl, image, name, className = "" }) {
+  const [imgError, setImgError] = useState(false);
   const src = imageUrl || image;
-  return isOnline && src ? (
+
+  return isOnline && src && !imgError ? (
     <img
       src={src}
       alt={name}
+      onError={() => setImgError(true)}
       className={`object-cover rounded-full border border-border flex-shrink-0 ${className}`}
     />
   ) : (

--- a/src/lib/axios.js
+++ b/src/lib/axios.js
@@ -3,7 +3,7 @@ import network, { OFFLINE_ERROR } from "../utils/network";
 
 const axiosInstance = axios.create({
   baseURL: window?.configs?.apiUrlData ? window.configs.apiUrlData : "",
-  timeout: 10000,
+  timeout: 100000,
   headers: {
     "Content-Type": "application/json",
   },

--- a/src/pages/HomePage/components/TimeRangeSelector.jsx
+++ b/src/pages/HomePage/components/TimeRangeSelector.jsx
@@ -770,7 +770,7 @@ export default function TimeRangeSelector({
   };
 
   return (
-    <div className="bg-background border-b border-border p-2 md:p-4 w-full mx-auto">
+    <div className="bg-card border-b border-border p-2 md:p-4 w-full mx-auto">
       {/* Presets and calendar */}
       <div className="hidden md:block pb-2 md:pb-4 px-1 text-primary text-center md:text-left md:px-0 text-xs md:text-sm font-medium md:font-semibold">
         Select a date range
@@ -815,9 +815,9 @@ export default function TimeRangeSelector({
               setActivePreset(preset.label);
               setActivePresident("");
             }}
-            className={`px-3 py-1 rounded-md text-xs md:text-sm font-medium transition-colors border ${activePreset === preset.label
-                ? "bg-accent text-primary-foreground border-accent"
-                : "bg-background text-foreground border-border hover:bg-muted"
+            className={`px-2 py-1 cursor-pointer rounded-md text-xs md:text-sm font-medium transition-colors border ${activePreset === preset.label
+              ? "bg-accent text-primary-foreground border-accent"
+              : "bg-card text-foreground border-border hover:bg-muted"
               }`}
           >
             {preset.label}
@@ -828,9 +828,9 @@ export default function TimeRangeSelector({
         <div className="relative w-full md:w-56 text-xs">
           {/* Main button */}
           <button
-            className={`w-full px-3 py-1.5 text-left font-medium cursor-pointer rounded-md focus:outline-none flex justify-between items-center ${activePresident
+            className={`w-full px-3 py-1.5 text-left font-medium cursor-pointer rounded-md focus:outline-none flex justify-between items-center border border-border ${activePresident
               ? "bg-accent/20 text-primary"
-              : "hover:bg-background/25 bg-foreground/10 text-primary hover:cursor-pointer"
+              : "hover:bg-muted bg-card text-primary hover:cursor-pointer"
               }`}
             onClick={() => setIsDropdownOpen((o) => !o)}
           >
@@ -957,12 +957,10 @@ export default function TimeRangeSelector({
               setCalendarEnd(endDate);
               setCalendarOpen((o) => !o);
             }}
-            className={`flex items-center justify-center gap-2 w-full sm:w-auto px-2.5 py-1.5 text-xs rounded-md transition-colors cursor-pointer
-      ${calendarRange &&
-                startDate.toISOString() === calendarRange.start &&
-                endDate.toISOString() === calendarRange.end
-                ? "bg-accent text-white hover:bg-accent"
-                : "bg-foreground/10 text-primary font-medium hover:bg-border"
+            className={`flex items-center justify-center w-full sm:w-auto px-4 py-1.5 text-xs font-medium cursor-pointer rounded-md focus:outline-none border border-border ${
+              calendarRange && startDate.toISOString() === calendarRange.start && endDate.toISOString() === calendarRange.end
+                ? "bg-accent/20 text-primary"
+                : "hover:bg-muted bg-card text-primary"
               }`}
           >
             By Date

--- a/src/pages/HomePage/components/TimeRangeSelector.jsx
+++ b/src/pages/HomePage/components/TimeRangeSelector.jsx
@@ -815,9 +815,9 @@ export default function TimeRangeSelector({
               setActivePreset(preset.label);
               setActivePresident("");
             }}
-            className={`p-1 md:p-1.5 text-xs font-medium rounded-sm transition-colors hover:cursor-pointer ${activePreset === preset.label
-              ? "bg-accent/20 text-primary"
-              : "hover:bg-background/25 bg-foreground/10 text-primary hover:cursor-pointer"
+            className={`px-3 py-1 rounded-md text-xs md:text-sm font-medium transition-colors border ${activePreset === preset.label
+                ? "bg-accent text-primary-foreground border-accent"
+                : "bg-background text-foreground border-border hover:bg-muted"
               }`}
           >
             {preset.label}

--- a/src/pages/HomePage/components/TimeRangeSelector.jsx
+++ b/src/pages/HomePage/components/TimeRangeSelector.jsx
@@ -957,10 +957,9 @@ export default function TimeRangeSelector({
               setCalendarEnd(endDate);
               setCalendarOpen((o) => !o);
             }}
-            className={`flex items-center justify-center w-full sm:w-auto px-4 py-1.5 text-xs font-medium cursor-pointer rounded-md focus:outline-none border border-border ${
-              calendarRange && startDate.toISOString() === calendarRange.start && endDate.toISOString() === calendarRange.end
-                ? "bg-accent/20 text-primary"
-                : "hover:bg-muted bg-card text-primary"
+            className={`flex items-center justify-center w-full sm:w-auto px-4 py-1.5 text-xs font-medium cursor-pointer rounded-md focus:outline-none border border-border ${calendarRange && startDate.toISOString() === calendarRange.start && endDate.toISOString() === calendarRange.end
+              ? "bg-accent/20 text-primary"
+              : "hover:bg-muted bg-card text-primary"
               }`}
           >
             By Date

--- a/src/pages/HomePage/components/TimeRangeSelector.jsx
+++ b/src/pages/HomePage/components/TimeRangeSelector.jsx
@@ -815,7 +815,7 @@ export default function TimeRangeSelector({
               setActivePreset(preset.label);
               setActivePresident("");
             }}
-            className={`px-2 py-1 cursor-pointer rounded-md text-xs md:text-sm font-medium transition-colors border ${activePreset === preset.label
+            className={`px-2 py-1 cursor-pointer rounded-md text-xs font-medium transition-colors border ${activePreset === preset.label
               ? "bg-accent text-primary-foreground border-accent"
               : "bg-card text-foreground border-border hover:bg-muted"
               }`}

--- a/src/pages/HomePage/screens/HomePage.jsx
+++ b/src/pages/HomePage/screens/HomePage.jsx
@@ -17,6 +17,7 @@ import ThemeToggle from "../../../components/theme-toggle";
 import ShareLinkButton from "../../../components/ShareLinkButton";
 import SearchBar from "../../../components/SearchBar";
 import SearchPage from "../../SearchPage/screens/SearchPage";
+import Error404 from "../../ErrorBoundaries/screens/404Error";
 import { toast } from "react-toastify";
 import SlFlag from "/sl_flag.png";
 
@@ -28,6 +29,11 @@ export default function HomePage() {
   const [isExpanded, setIsExpanded] = useState(window.innerWidth >= 768);
   const navigate = useNavigate();
   const { tab } = useParams();
+
+  const validTabs = ["executive-branch", "data", "search"];
+  if (tab && !validTabs.includes(tab)) {
+    return <Error404 />;
+  }
 
   const selectedTab = tab || "executive-branch";
 

--- a/src/pages/HomePage/screens/HomePage.jsx
+++ b/src/pages/HomePage/screens/HomePage.jsx
@@ -29,7 +29,7 @@ export default function HomePage() {
   const navigate = useNavigate();
   const { tab } = useParams();
 
-  const selectedTab = tab || "organization";
+  const selectedTab = tab || "executive-branch";
 
   const gazetteDateClassic = useSelector(
     (state) => state.gazettes.gazetteDataClassic
@@ -113,7 +113,7 @@ export default function HomePage() {
     params.delete("ministry");
     params.delete("viewMode");
 
-    if (tabName === "organization") {
+    if (tabName === "executive-branch") {
       params.delete("categoryIds");
       params.delete("datasetId");
       params.delete("datasetName");
@@ -173,14 +173,14 @@ export default function HomePage() {
 
         <nav className="flex flex-col text-foreground w-full gap-1 relative top-0 flex-1 mt-8">
           <button
-            className={`text-xs md:text-sm ${selectedTab === "organization"
+            className={`text-xs md:text-sm ${selectedTab === "executive-branch"
               ? "bg-accent text-primary-foreground font-semibold"
               : "hover:bg-background-dark/85"
               }  hover:cursor-pointer ${isExpanded ? "px-2 md:px-4" : "px-0"} py-2 md:py-3 rounded-md transition-all ease-in-out text-left flex items-center`}
-            onClick={() => handleTabChange("organization")}
+            onClick={() => handleTabChange("executive-branch")}
           >
             <Binoculars className={`${isExpanded ? "mr-2 md:mr-3" : "mx-auto"}`} />
-            {isExpanded && "Organization"}
+            {isExpanded && "Executive Branch"}
           </button>
           <button
             className={`text-xs md:text-sm ${selectedTab === "data"
@@ -263,7 +263,7 @@ export default function HomePage() {
           {selectedTab !== "search" && (
             <TimeRangeSelector
               startYear={2019}
-              dates={selectedTab === "organization" ? dates : []}
+              dates={selectedTab === "executive-branch" ? dates : []}
               onDateChange={handleDateRangeChange}
               externalRange={externalDateRange}
               activePreset={activePreset}
@@ -273,7 +273,7 @@ export default function HomePage() {
             />
           )}
 
-          {selectedTab === "organization" ? (
+          {selectedTab === "executive-branch" ? (
             <Organization dateRange={userSelectedDateRange} />
           ) : selectedTab === "data" ? (
             <DataPage setExternalDateRange={setExternalDateRange} />

--- a/src/pages/HomePage/screens/HomePage.jsx
+++ b/src/pages/HomePage/screens/HomePage.jsx
@@ -31,9 +31,6 @@ export default function HomePage() {
   const { tab } = useParams();
 
   const validTabs = ["executive-branch", "data", "search"];
-  if (tab && !validTabs.includes(tab)) {
-    return <Error404 />;
-  }
 
   const selectedTab = tab || "executive-branch";
 
@@ -133,6 +130,10 @@ export default function HomePage() {
       search: params.toString() ? `?${params.toString()}` : "",
     });
   };
+
+  if (tab && !validTabs.includes(tab)) {
+    return <Error404 />;
+  }
 
   return (
     <div className="flex">

--- a/src/pages/OrganizationPage/components/FilteredPresidentCards.jsx
+++ b/src/pages/OrganizationPage/components/FilteredPresidentCards.jsx
@@ -7,7 +7,7 @@ import {
 } from "../../../store/presidencySlice";
 import { setGazetteData } from "../../../store/gazetteDate";
 import { Link, useLocation } from "react-router-dom";
-import { EyeIcon, Calendar } from "lucide-react";
+import { EyeIcon } from "lucide-react";
 import useNetworkStatus from "../../../hooks/useNetworkStatus";
 import PersonAvatar from "../../../components/PersonAvatar";
 
@@ -154,7 +154,15 @@ export default function FilteredPresidentCards({ dateRange = [null, null] }) {
       }
     }
 
-    const validSelectedDate = urlSelectedDate;
+    let validSelectedDate = urlSelectedDate;
+    
+    // If selectedDate is missing but we're in the changes view with compareDates, use the first date from compareDates
+    if (!validSelectedDate) {
+      const compareDates = params.get("compareDates");
+      if (compareDates) {
+        validSelectedDate = compareDates.split(",")[0];
+      }
+    }
 
     if (validSelectedDate) {
       const urlRange = [new Date(urlStartDate), new Date(urlEndDate)];
@@ -182,6 +190,7 @@ export default function FilteredPresidentCards({ dateRange = [null, null] }) {
         selectPresidentAndDates(presidentForDate, urlRange, validSelectedDate);
         setInitializedFromUrl(true);
         setUrlInitComplete(true);
+        lastProcessedUrlRef.current = window.location.search;
         return;
       }
     }
@@ -229,8 +238,8 @@ export default function FilteredPresidentCards({ dateRange = [null, null] }) {
     const dateRangeMatchesUrl =
       currStart && currEnd &&
       urlStartDate && urlEndDate &&
-      currStart.toISOString().split("T")[0] === urlStartDate &&
-      currEnd.toISOString().split("T")[0] === urlEndDate;
+      currStart.toLocaleDateString("en-CA") === urlStartDate &&
+      currEnd.toLocaleDateString("en-CA") === urlEndDate;
 
     // If date range doesn't match URL AND it's not a minister search navigation, 
     // this is a manual change - clear the processed URL
@@ -239,7 +248,10 @@ export default function FilteredPresidentCards({ dateRange = [null, null] }) {
     }
 
     // Don't auto-select if we just processed a URL change AND the date range matches that URL
-    if (lastProcessedUrlRef.current === currentUrlSearch && dateRangeMatchesUrl && currentUrlSearch.includes('selectedDate')) {
+    const isChangesView = params.get("view") === "changes";
+    const hasValidUrlState = currentUrlSearch.includes('selectedDate') || (isChangesView && currentUrlSearch.includes('compareDates'));
+
+    if (lastProcessedUrlRef.current === currentUrlSearch && dateRangeMatchesUrl && hasValidUrlState) {
       prevDateRangeRef.current = dateRange;
       return;
     }
@@ -257,7 +269,7 @@ export default function FilteredPresidentCards({ dateRange = [null, null] }) {
   useEffect(() => {
     if (!selectedDate?.date) return;
     const params = new URLSearchParams(window.location.search);
-    if (params.get("view") === "department-flow") return;
+    if (params.get("view") === "changes") return;
     const prevSelectedDate = params.get("selectedDate");
     const url = new URL(window.location.href);
     url.searchParams.set("selectedDate", selectedDate.date);

--- a/src/pages/OrganizationPage/components/FilteredPresidentCards.jsx
+++ b/src/pages/OrganizationPage/components/FilteredPresidentCards.jsx
@@ -267,7 +267,7 @@ export default function FilteredPresidentCards({ dateRange = [null, null] }) {
     window.history.replaceState({}, "", url.toString());
   }, [selectedDate, location.search]);
 
-  // Monitor URL parameter changes when already on /organization route
+  // Monitor URL parameter changes when already on /executive-branch route
   useEffect(() => {
     // Only run after initial URL initialization is complete
     if (!initializedFromUrl) return;

--- a/src/pages/OrganizationPage/components/FilteredPresidentCards.jsx
+++ b/src/pages/OrganizationPage/components/FilteredPresidentCards.jsx
@@ -155,7 +155,7 @@ export default function FilteredPresidentCards({ dateRange = [null, null] }) {
     }
 
     let validSelectedDate = urlSelectedDate;
-    
+
     // If selectedDate is missing but we're in the changes view with compareDates, use the first date from compareDates
     if (!validSelectedDate) {
       const compareDates = params.get("compareDates");
@@ -238,8 +238,8 @@ export default function FilteredPresidentCards({ dateRange = [null, null] }) {
     const dateRangeMatchesUrl =
       currStart && currEnd &&
       urlStartDate && urlEndDate &&
-      currStart.toLocaleDateString("en-CA") === urlStartDate &&
-      currEnd.toLocaleDateString("en-CA") === urlEndDate;
+      currStart.toISOString().split("T")[0] === urlStartDate &&
+      currEnd.toISOString().split("T")[0] === urlEndDate;
 
     // If date range doesn't match URL AND it's not a minister search navigation, 
     // this is a manual change - clear the processed URL

--- a/src/pages/OrganizationPage/components/FilteredPresidentCards.jsx
+++ b/src/pages/OrganizationPage/components/FilteredPresidentCards.jsx
@@ -363,8 +363,8 @@ export default function FilteredPresidentCards({ dateRange = [null, null] }) {
                 onClick={() => selectPresidentAndDates(president)}
                 className={`min-w-[60vw] sm:min-w-[300px] md:min-w-0 flex-shrink-0 snap-center flex items-center p-1.5 md:p-2 rounded-lg border transition-all duration-200 hover:cursor-pointer
     ${isSelected
-                    ? "bg-accent/20 border-accent/35 shadow-md"
-                    : "bg-foreground/5 border-primary/15 hover:bg-foreground/15"
+                    ? "bg-accent/20 border-accent/35 shadow-md opacity-100"
+                    : "bg-card border-border shadow-sm opacity-80 hover:opacity-100 hover:bg-muted"
                   }`}
               >
                 <PersonAvatar

--- a/src/pages/OrganizationPage/components/FilteredPresidentCards.jsx
+++ b/src/pages/OrganizationPage/components/FilteredPresidentCards.jsx
@@ -7,7 +7,7 @@ import {
 } from "../../../store/presidencySlice";
 import { setGazetteData } from "../../../store/gazetteDate";
 import { Link, useLocation } from "react-router-dom";
-import { EyeIcon } from "lucide-react";
+import { EyeIcon, Calendar } from "lucide-react";
 import useNetworkStatus from "../../../hooks/useNetworkStatus";
 import PersonAvatar from "../../../components/PersonAvatar";
 
@@ -332,6 +332,11 @@ export default function FilteredPresidentCards({ dateRange = [null, null] }) {
 
   return (
     <div className="rounded-lg w-full">
+      {dateRange && dateRange[0] && dateRange[1] && (
+        <div className="text-center text-[10px] md:text-xs text-primary/60 mb-4 px-1">
+          Presidents During This Period: {new Date(dateRange[0]).toLocaleDateString("en-CA")} to {new Date(dateRange[1]).toLocaleDateString("en-CA")}
+        </div>
+      )}
       {filteredPresidents.length > 4 && (
         <input
           type="text"
@@ -364,7 +369,7 @@ export default function FilteredPresidentCards({ dateRange = [null, null] }) {
                 className={`min-w-[60vw] sm:min-w-[300px] md:min-w-0 flex-shrink-0 snap-center flex items-center p-1.5 md:p-2 rounded-lg border transition-all duration-200 hover:cursor-pointer
     ${isSelected
                     ? "bg-accent/20 border-accent/35 shadow-md opacity-100"
-                    : "bg-card border-border shadow-sm opacity-80 hover:opacity-100 hover:bg-muted"
+                    : "bg-card border-border shadow-sm opacity-80 hover:opacity-100 hover:bg-accent/10 hover:border-accent/20"
                   }`}
               >
                 <PersonAvatar

--- a/src/pages/OrganizationPage/components/FilteredPresidentCards.jsx
+++ b/src/pages/OrganizationPage/components/FilteredPresidentCards.jsx
@@ -334,7 +334,7 @@ export default function FilteredPresidentCards({ dateRange = [null, null] }) {
     <div className="rounded-lg w-full">
       {dateRange && dateRange[0] && dateRange[1] && (
         <div className="text-center text-[10px] md:text-xs text-primary/60 mb-4 px-1">
-          Presidents During This Period: {new Date(dateRange[0]).toLocaleDateString("en-CA")} to {new Date(dateRange[1]).toLocaleDateString("en-CA")}
+          Presidents During The Period {new Date(dateRange[0]).toLocaleDateString("en-CA")} to {new Date(dateRange[1]).toLocaleDateString("en-CA")}
         </div>
       )}
       {filteredPresidents.length > 4 && (
@@ -394,7 +394,7 @@ export default function FilteredPresidentCards({ dateRange = [null, null] }) {
                       to={`/person-profile/${president?.id}`}
                       onClick={(e) => e.stopPropagation()}
                       state={{ mode: "back", from: location.pathname + location.search }}
-                      className="text-primary/75 text-xs md:text-sm hover:text-accent transition-all animation duration-200 mt-1 flex"
+                      className="text-primary/75 text-xs md:text-sm hover:text-accent transition-all animation duration-200 mt-1 flex items-center"
                     >
                       <EyeIcon size={16} className="mr-1" />
                       <p>View Profile</p>

--- a/src/pages/OrganizationPage/components/GazetteTimeline.jsx
+++ b/src/pages/OrganizationPage/components/GazetteTimeline.jsx
@@ -11,7 +11,7 @@ import { Tooltip } from "@mui/material";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import { Divide, Files } from "lucide-react";
 
-export default function GazetteTimeline() {
+export default function GazetteTimeline({ multiSelect = false, multiSelectedDates = [], onMultiSelectChange }) {
   const dispatch = useDispatch();
 
   //redux state
@@ -67,23 +67,23 @@ export default function GazetteTimeline() {
   };
 
   const drawLine = () => {
-    if (!avatarRef.current || !dotRef.current || !scrollRef.current) {
+    if (!dotRef.current || !scrollRef.current) {
       setLineStyle(null);
       return;
     }
 
-    const avatarBox = avatarRef.current.getBoundingClientRect();
     const dotBox = dotRef.current.getBoundingClientRect();
     const containerBox =
       scrollRef.current.parentElement.getBoundingClientRect();
 
-    const startX = avatarBox.left + avatarBox.width;
+    // Start from the very left edge of the container
+    const startX = containerBox.left;
     const endX = dotBox.left + dotBox.width / 2;
     const containerHeight = containerBox.height;
     const top = containerHeight / 2 - 30;
 
     setLineStyle({
-      left: startX - containerBox.left,
+      left: 0,
       width: endX - startX,
       top,
     });
@@ -125,7 +125,7 @@ export default function GazetteTimeline() {
         });
       }, 100);
     }
-  }, [selectedDate, gazetteData]);
+  }, [selectedDate, gazetteData, multiSelect]);
 
   return (
     <Box
@@ -137,6 +137,18 @@ export default function GazetteTimeline() {
         mb: { xs: "-20px", md: "auto" }
       }}
     >
+      {gazetteData?.length > 0 && (
+        <Typography
+          sx={{
+            mb: "30px",
+            fontSize: { xs: "0.7rem", md: "0.95rem" },
+            color: `${colors.textPrimary}99`,
+          }}
+        >
+          {selectedPresident ? `${utils.extractNameFromProtobuf(selectedPresident?.name).split(" ")[0]}'s` : "Gazettes"} published dates
+        </Typography>
+      )}
+
       {selectedPresident && (
         <Box
           sx={{
@@ -181,7 +193,7 @@ export default function GazetteTimeline() {
             }}
           />
 
-          {lineStyle && selectedDate && (
+          {!multiSelect && lineStyle && selectedDate && (
             <Box
               sx={{
                 position: "absolute",
@@ -197,90 +209,7 @@ export default function GazetteTimeline() {
             />
           )}
 
-          {selectedPresident && (
-            <Box
-              sx={{
-                position: "absolute",
-                zIndex: 9,
-                display: "flex",
-                alignItems: "center",
-                gap: 2,
-                flexShrink: 0,
-                transition: "all 0.3s ease",
-                pointerEvents: "none",
-              }}
-            >
-              {selectedPresident.id === latestPresidentId ? (
-                <Box
-                  sx={{
-                    textAlign: "center",
-                    minWidth: { xs: 60, sm: 80 },
-                    background: `linear-gradient(to right, ${colors.backgroundPrimary} 65%, rgba(0,0,0,0) 50%)`,
-                  }}
-                >
-                  <StyledBadge
-                    ref={avatarRef}
-                    overlap="circular"
-                    anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-                    variant="dot"
-                    sx={{
-                      border: `4px solid ${selectedPresident?.themeColorLight ||
-                        colors.timelineColor
-                        }`,
-                      backgroundColor: colors.backgroundPrimary,
-                      margin: "auto",
-                      borderRadius: 50,
-                    }}
-                  >
-                    <Avatar
-                      alt={selectedPresident.name}
-                      src={selectedPresident.imageUrl}
-                      sx={{
-                        width: { xs: 40, sm: 50 },
-                        height: { xs: 40, sm: 50 },
-                        border: `3px solid ${colors.backgroundPrimary}`,
-                        backgroundColor: colors.backgroundPrimary,
-                        margin: "auto",
-                      }}
-                    />
-                  </StyledBadge>
-                  <Typography
-                    variant="body2"
-                    sx={{
-                      mt: 1,
-                      color: colors.textPrimary,
-                      fontFamily: "poppins",
-                      fontWeight: 600,
-                    }}
-                  >
-                    {utils.extractNameFromProtobuf(selectedPresident.name)}
-                  </Typography>
 
-                  <Typography
-                    variant="caption"
-                    sx={{ color: colors.textMuted, fontFamily: "poppins" }}
-                  >
-                    {selectedPresident.created.split("-")[0]} -{" "}
-                    {selectedPresident.endTime
-                      ? new Date(selectedPresident.endTime).getFullYear()
-                      : "Present"}
-                  </Typography>
-                </Box>
-              ) : (
-                <Box
-                  ref={avatarRef}
-                  sx={{
-                    display: "none",
-                    border: `3px solid ${colors.backgroundPrimary}`,
-                    backgroundColor: colors.backgroundPrimary,
-                    margin: "auto",
-                  }}
-                >
-                  <Box />
-                </Box>
-              )}
-            </Box>
-          )}
 
           <Box
             ref={scrollRef}
@@ -306,11 +235,19 @@ export default function GazetteTimeline() {
           >
             {gazetteData?.length > 0 ? (
               gazetteData.map((item) => {
-                const isDateSelected = selectedDate?.date === item.date;
+                const isDateSelected = multiSelect 
+                  ? multiSelectedDates.includes(item.date) 
+                  : selectedDate?.date === item.date;
                 return (
                   <Box
                     key={item.date}
-                    onClick={() => dispatch(setSelectedDate(item))}
+                    onClick={() => {
+                      if (multiSelect) {
+                        onMultiSelectChange(item.date);
+                      } else {
+                        dispatch(setSelectedDate(item));
+                      }
+                    }}
                     sx={{
                       display: "flex",
                       flexDirection: "column",
@@ -348,7 +285,7 @@ export default function GazetteTimeline() {
                       arrow
                     >
                       <Box
-                        ref={isDateSelected ? dotRef : null}
+                        ref={isDateSelected && !multiSelect ? dotRef : null}
                         sx={{
                           width: isDateSelected ? 20 : 15,
                           height: isDateSelected ? 20 : 15,
@@ -447,18 +384,6 @@ export default function GazetteTimeline() {
         </Box>
       )}
       <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", width: "100%" }}>
-        {gazetteData?.length > 0 && (
-          <Typography
-            sx={{
-              mt: "-50px",
-              mb: "30px",
-              fontSize: { xs: "0.7rem", md: "0.95rem" },
-              color: `${colors.textPrimary}99`,
-            }}
-          >
-            Gazettes published dates
-          </Typography>
-        )}
         {gazetteData?.length == 0 && selectedDate && (
           <Typography
             variant="caption"

--- a/src/pages/OrganizationPage/components/GazetteTimeline.jsx
+++ b/src/pages/OrganizationPage/components/GazetteTimeline.jsx
@@ -9,7 +9,7 @@ import StyledBadge from "../../../components/materialCustomAvatar";
 import { useThemeContext } from "../../../context/themeContext";
 import { Tooltip } from "@mui/material";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
-import { Divide, Files } from "lucide-react";
+import { Divide, Files, Calendar } from "lucide-react";
 
 export default function GazetteTimeline({ multiSelect = false, multiSelectedDates = [], onMultiSelectChange }) {
   const dispatch = useDispatch();
@@ -132,21 +132,14 @@ export default function GazetteTimeline({ multiSelect = false, multiSelectedDate
       sx={{
         display: "flex",
         flexDirection: "column",
-        gap: 2,
         width: "100%",
-        mb: { xs: "-20px", md: "auto" }
+        mb: { xs: -1, md: -3 }
       }}
     >
-      {gazetteData?.length > 0 && (
-        <Typography
-          sx={{
-            fontSize: { xs: "0.7rem", md: "0.95rem" },
-            color: `${colors.textPrimary}99`,
-            textAlign: "center",
-          }}
-        >
-          {selectedPresident && (`${utils.extractNameFromProtobuf(selectedPresident?.name).split(" ")[0]}'s Gazettes published dates`)}
-        </Typography>
+      {gazetteData?.length > 0 && selectedPresident && (
+        <div className="text-center text-[10px] md:text-xs text-primary/60 px-1 mt-2">
+          {utils.extractNameFromProtobuf(selectedPresident.name).split(" ").slice(0, 2).join(" ")}'s Gazettes published dates
+        </div>
       )}
 
       {selectedPresident && (
@@ -216,7 +209,7 @@ export default function GazetteTimeline({ multiSelect = false, multiSelectedDate
             sx={{
               display: "flex",
               overflowX: "auto",
-              gap: 2,
+              gap: { xs: 4, sm: 3.25 },
               padding: { xs: 2, sm: 4 },
               paddingLeft: { xs: 22, sm: 28 },
               paddingRight: { xs: 8, sm: 14 },

--- a/src/pages/OrganizationPage/components/GazetteTimeline.jsx
+++ b/src/pages/OrganizationPage/components/GazetteTimeline.jsx
@@ -138,7 +138,7 @@ export default function GazetteTimeline({ multiSelect = false, multiSelectedDate
     >
       {gazetteData?.length > 0 && selectedPresident && (
         <div className="text-center text-[10px] md:text-xs text-primary/60 px-1 mt-2">
-          {utils.extractNameFromProtobuf(selectedPresident.name).split(" ").slice(0, 2).join(" ")}'s Gazettes published dates
+          {utils.extractNameFromProtobuf(selectedPresident.name).split(" ").slice(0, 2).join(" ")}'s Gazette Publication Dates
         </div>
       )}
 

--- a/src/pages/OrganizationPage/components/GazetteTimeline.jsx
+++ b/src/pages/OrganizationPage/components/GazetteTimeline.jsx
@@ -1,15 +1,13 @@
-import { useEffect, useRef, useState, useCallback } from "react";
-import { Box, Avatar, Typography, IconButton, Divider } from "@mui/material";
+import { useEffect, useRef, useState } from "react";
+import { Box, Typography, IconButton } from "@mui/material";
 import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
 import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
 import { useSelector, useDispatch } from "react-redux";
 import { setSelectedDate } from "../../../store/presidencySlice";
 import utils from "../../../utils/utils";
-import StyledBadge from "../../../components/materialCustomAvatar";
 import { useThemeContext } from "../../../context/themeContext";
 import { Tooltip } from "@mui/material";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
-import { Divide, Files, Calendar } from "lucide-react";
 
 export default function GazetteTimeline({ multiSelect = false, multiSelectedDates = [], onMultiSelectChange }) {
   const dispatch = useDispatch();
@@ -24,14 +22,12 @@ export default function GazetteTimeline({ multiSelect = false, multiSelectedDate
 
   //ref
   const scrollRef = useRef(null);
-  const avatarRef = useRef(null);
   const dotRef = useRef(null);
 
   //states
   const [lineStyle, setLineStyle] = useState(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
-  const [latestPresidentId, setLatestPresidentId] = useState(null);
 
   const { colors } = useThemeContext();
 

--- a/src/pages/OrganizationPage/components/GazetteTimeline.jsx
+++ b/src/pages/OrganizationPage/components/GazetteTimeline.jsx
@@ -140,12 +140,12 @@ export default function GazetteTimeline({ multiSelect = false, multiSelectedDate
       {gazetteData?.length > 0 && (
         <Typography
           sx={{
-            mb: "30px",
             fontSize: { xs: "0.7rem", md: "0.95rem" },
             color: `${colors.textPrimary}99`,
+            textAlign: "center",
           }}
         >
-          {selectedPresident ? `${utils.extractNameFromProtobuf(selectedPresident?.name).split(" ")[0]}'s` : "Gazettes"} published dates
+          {selectedPresident && (`${utils.extractNameFromProtobuf(selectedPresident?.name).split(" ")[0]}'s Gazettes published dates`)}
         </Typography>
       )}
 
@@ -235,8 +235,8 @@ export default function GazetteTimeline({ multiSelect = false, multiSelectedDate
           >
             {gazetteData?.length > 0 ? (
               gazetteData.map((item) => {
-                const isDateSelected = multiSelect 
-                  ? multiSelectedDates.includes(item.date) 
+                const isDateSelected = multiSelect
+                  ? multiSelectedDates.includes(item.date)
                   : selectedDate?.date === item.date;
                 return (
                   <Box

--- a/src/pages/OrganizationPage/components/MinistryCardGrid.jsx
+++ b/src/pages/OrganizationPage/components/MinistryCardGrid.jsx
@@ -201,7 +201,7 @@ const MinistryCardGrid = () => {
       if (params.has("ministry")) {
         params.delete("ministry");
         navigate(`${window.location.pathname}?${params.toString()}`);
-      } 
+      }
 
       setActiveStep(0);
       setSelectedCard(null);
@@ -222,13 +222,7 @@ const MinistryCardGrid = () => {
   };
 
   return (
-    <Box
-      sx={{
-        px: { xs: 1, sm: 1, md: 2, lg: 2, xl: 2 },
-        mt: -2,
-        my: 2,
-      }}
-    >
+    <Box>
       <Box
         sx={{
           display: "grid",

--- a/src/pages/OrganizationPage/screens/Organization.jsx
+++ b/src/pages/OrganizationPage/screens/Organization.jsx
@@ -43,14 +43,16 @@ const Organization = ({ dateRange }) => {
     });
   }, [setSearchParams]);
 
-  const lastResetPresidentId = useRef(null);
+  const lastResetState = useRef(null);
   const isFirstMount = useRef(true);
 
   useEffect(() => {
     if (!selectedPresident || !gazetteData || gazetteData.length === 0) return;
 
-    if (lastResetPresidentId.current !== selectedPresident.id) {
-      lastResetPresidentId.current = selectedPresident.id;
+    const currentStateKey = `${selectedPresident.id}-${activeView}`;
+
+    if (lastResetState.current !== currentStateKey) {
+      lastResetState.current = currentStateKey;
 
       if (activeView === "structure") {
         const lastGazette = gazetteData[gazetteData.length - 1];

--- a/src/pages/OrganizationPage/screens/Organization.jsx
+++ b/src/pages/OrganizationPage/screens/Organization.jsx
@@ -142,56 +142,59 @@ const Organization = ({ dateRange }) => {
     <div>
       {/* FilteredPresidentCards Component */}
       {dateRange[0] && dateRange[1] && (
-        <div className="mb-1 md:mb-6 px-2 md:px-4">
+        <div className="mb-4 px-2 md:px-4">
           <FilteredPresidentCards dateRange={dateRange} />
         </div>
       )}
 
-      {/* Gazette Timeline visible for both views */}
-      <GazetteTimeline
-        multiSelect={activeView === "department-flow"}
-        multiSelectedDates={multiSelectedDates}
-        onMultiSelectChange={handleMultiSelectChange}
-      />
+      {/* Card wrapper for Timeline and Content */}
+      <div className="bg-card rounded-lg border border-border p-2 md:p-4 mx-2 md:mx-4 mb-4">
+        {/* Gazette Timeline visible for both views */}
+        <GazetteTimeline
+          multiSelect={activeView === "department-flow"}
+          multiSelectedDates={multiSelectedDates}
+          onMultiSelectChange={handleMultiSelectChange}
+        />
 
-      {/* View Toggle Tabs (Moved below GazetteTimeline) */}
-      <div className="flex border-b border-border mt-2 mb-4 px-2 md:px-4 gap-1">
-        <button
-          onClick={() => toggleView("cabinet-structure")}
-          className={`px-4 py-2 text-sm font-medium transition-all duration-200 hover:cursor-pointer rounded-t-lg border-t border-l border-r ${activeView === "cabinet-structure"
-            ? "bg-background border-border text-foreground -mb-[1px] shadow-sm z-10"
-            : "bg-muted border-transparent text-muted-foreground hover:bg-muted/80 hover:text-foreground"
-            }`}
-        >
-          Structure
-        </button>
-        <button
-          onClick={() => toggleView("department-flow")}
-          className={`px-4 py-2 text-sm font-medium transition-all duration-200 hover:cursor-pointer rounded-t-lg border-t border-l border-r ${activeView === "department-flow"
-            ? "bg-background border-border text-foreground -mb-[1px] shadow-sm z-10"
-            : "bg-muted border-transparent text-muted-foreground hover:bg-muted/80 hover:text-foreground"
-            }`}
-        >
-          Changes
-        </button>
+        {/* View Toggle Tabs (Moved below GazetteTimeline) */}
+        <div className="flex border-b border-border mt-2 mb-4 gap-1">
+          <button
+            onClick={() => toggleView("cabinet-structure")}
+            className={`px-4 py-2 text-sm font-medium transition-all duration-200 hover:cursor-pointer rounded-t-lg border-t border-l border-r ${activeView === "cabinet-structure"
+              ? "bg-card border-border text-foreground -mb-[1px] shadow-sm z-10"
+              : "bg-muted border-transparent text-muted-foreground hover:bg-muted/80 hover:text-foreground"
+              }`}
+          >
+            Structure
+          </button>
+          <button
+            onClick={() => toggleView("department-flow")}
+            className={`px-4 py-2 text-sm font-medium transition-all duration-200 hover:cursor-pointer rounded-t-lg border-t border-l border-r ${activeView === "department-flow"
+              ? "bg-card border-border text-foreground -mb-[1px] shadow-sm z-10"
+              : "bg-muted border-transparent text-muted-foreground hover:bg-muted/80 hover:text-foreground"
+              }`}
+          >
+            Changes
+          </button>
+        </div>
+
+        {/* Conditional rendering based on active view */}
+        {activeView === "cabinet-structure" ? (
+          <>
+            {selectedPresident && <>{selectedDate != null && <MinistryCardGrid />}</>}
+          </>
+        ) : (
+          <LandscapeRequired onBack={() => toggleView("cabinet-structure")}>
+            <CabinetFlow
+              key={selectedPresident?.id}
+              presidentId={selectedPresident?.id}
+              dateRange={dateRange}
+              selectedDates={multiSelectedDates}
+              onMinistryNodeClick={handleMinistryNodeClick}
+            />
+          </LandscapeRequired>
+        )}
       </div>
-
-      {/* Conditional rendering based on active view */}
-      {activeView === "cabinet-structure" ? (
-        <>
-          {selectedPresident && <>{selectedDate != null && <MinistryCardGrid />}</>}
-        </>
-      ) : (
-        <LandscapeRequired onBack={() => toggleView("cabinet-structure")}>
-          <CabinetFlow
-            key={selectedPresident?.id}
-            presidentId={selectedPresident?.id}
-            dateRange={dateRange}
-            selectedDates={multiSelectedDates}
-            onMinistryNodeClick={handleMinistryNodeClick}
-          />
-        </LandscapeRequired>
-      )}
     </div>
   );
 };

--- a/src/pages/OrganizationPage/screens/Organization.jsx
+++ b/src/pages/OrganizationPage/screens/Organization.jsx
@@ -147,34 +147,42 @@ const Organization = ({ dateRange }) => {
         </div>
       )}
 
-      {/* Card wrapper for Timeline and Content */}
-      <div className="bg-card rounded-lg border border-border p-2 md:p-4 mx-2 md:mx-4 mb-4">
-        {/* Gazette Timeline visible for both views */}
+      {/* Gazette Timeline (Moved outside the white box) */}
+      <div className="px-2 md:px-4">
         <GazetteTimeline
           multiSelect={activeView === "department-flow"}
           multiSelectedDates={multiSelectedDates}
           onMultiSelectChange={handleMultiSelectChange}
         />
+      </div>
 
-        {/* View Toggle Tabs (Moved below GazetteTimeline) */}
-        <div className="flex border-b border-border mt-2 mb-4 gap-1">
+      {/* Card wrapper for Content */}
+      <div className="bg-card rounded-lg border border-border p-2 md:p-4 mx-2 md:mx-4 mb-4">
+        {/* View Toggle Tabs */}
+        <div className="flex items-end border-b border-border mb-4 gap-2 px-2">
           <button
             onClick={() => toggleView("cabinet-structure")}
-            className={`px-4 py-2 text-sm font-medium transition-all duration-200 hover:cursor-pointer rounded-t-lg border-t border-l border-r ${activeView === "cabinet-structure"
-              ? "bg-card border-border text-foreground -mb-[1px] shadow-sm z-10"
-              : "bg-muted border-transparent text-muted-foreground hover:bg-muted/80 hover:text-foreground"
+            className={`min-w-[140px] md:min-w-[160px] px-6 py-2.5 text-sm font-semibold transition-all duration-200 hover:cursor-pointer rounded-t-xl border-t border-l border-r relative ${activeView === "cabinet-structure"
+              ? "bg-card border-border text-primary"
+              : "bg-muted border-transparent text-primary/60 hover:bg-muted/80 hover:text-primary"
               }`}
           >
             Structure
+            {activeView === "cabinet-structure" && (
+              <div className="absolute -bottom-[1px] left-0 right-0 h-[2px] bg-card" />
+            )}
           </button>
           <button
             onClick={() => toggleView("department-flow")}
-            className={`px-4 py-2 text-sm font-medium transition-all duration-200 hover:cursor-pointer rounded-t-lg border-t border-l border-r ${activeView === "department-flow"
-              ? "bg-card border-border text-foreground -mb-[1px] shadow-sm z-10"
-              : "bg-muted border-transparent text-muted-foreground hover:bg-muted/80 hover:text-foreground"
+            className={`min-w-[140px] md:min-w-[160px] px-6 py-2.5 text-sm font-semibold transition-all duration-200 hover:cursor-pointer rounded-t-xl border-t border-l border-r relative ${activeView === "department-flow"
+              ? "bg-card border-border text-primary"
+              : "bg-muted border-transparent text-primary/60 hover:bg-muted/80 hover:text-primary"
               }`}
           >
             Changes
+            {activeView === "department-flow" && (
+              <div className="absolute -bottom-[1px] left-0 right-0 h-[2px] bg-card" />
+            )}
           </button>
         </div>
 

--- a/src/pages/OrganizationPage/screens/Organization.jsx
+++ b/src/pages/OrganizationPage/screens/Organization.jsx
@@ -26,7 +26,7 @@ const Organization = ({ dateRange }) => {
 
   const handleMultiSelectChange = useCallback((date) => {
     setMultiSelectedDates((prev) =>
-      prev.includes(date) ? prev.filter((d) => d !== date) : [...prev, date].slice(-3) // Max 3 dates allowed
+      prev.includes(date) ? prev.filter((d) => d !== date) : [...prev, date].slice(-10) // Max 10 dates allowed
     );
   }, []);
 

--- a/src/pages/OrganizationPage/screens/Organization.jsx
+++ b/src/pages/OrganizationPage/screens/Organization.jsx
@@ -1,7 +1,7 @@
 import GazetteTimeline from "../components/GazetteTimeline";
 import MinistryCardGrid from "../components/MinistryCardGrid";
 import { useDispatch, useSelector } from "react-redux";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, useRef } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import FilteredPresidentCards from "../components/FilteredPresidentCards";
 import CabinetFlow from "../../cabinetFlowPage/screens/CabinetFlow"
@@ -20,6 +20,57 @@ const Organization = ({ dateRange }) => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const [activeView, setActiveView] = useState(searchParams.get('view') || 'cabinet-structure');
+  const [multiSelectedDates, setMultiSelectedDates] = useState([]);
+
+  const presidentRelationDict = useSelector((s) => s.presidency.presidentRelationDict);
+
+  const handleMultiSelectChange = useCallback((date) => {
+    setMultiSelectedDates((prev) =>
+      prev.includes(date) ? prev.filter((d) => d !== date) : [...prev, date].slice(-3) // Max 3 dates allowed
+    );
+  }, []);
+
+  const lastResetPresidentId = useRef(null);
+
+  useEffect(() => {
+    if (!selectedPresident || !gazetteData || gazetteData.length === 0) return;
+
+    if (lastResetPresidentId.current !== selectedPresident.id) {
+      lastResetPresidentId.current = selectedPresident.id;
+
+      if (activeView === "cabinet-structure") {
+        const lastGazette = gazetteData[gazetteData.length - 1];
+        if (lastGazette) {
+          dispatch(setSelectedDate(lastGazette));
+        }
+      } else if (activeView === "department-flow") {
+        const firstGazette = gazetteData[0];
+        const lastGazette = gazetteData[gazetteData.length - 1];
+
+        const newDates = [];
+        if (firstGazette?.date) newDates.push(firstGazette.date);
+        if (lastGazette?.date && lastGazette.date !== firstGazette?.date) {
+          newDates.push(lastGazette.date);
+        }
+        setMultiSelectedDates(newDates);
+      }
+    }
+  }, [selectedPresident, gazetteData, activeView, dispatch]);
+
+  // Aggressive fallback to ensure the timeline always has defaults on refresh or when cleared in Changes tab
+  useEffect(() => {
+    if (activeView === "department-flow" && multiSelectedDates.length === 0 && gazetteData?.length > 0) {
+      const firstGazette = gazetteData[0];
+      const lastGazette = gazetteData[gazetteData.length - 1];
+
+      const newDates = [];
+      if (firstGazette?.date) newDates.push(firstGazette.date);
+      if (lastGazette?.date && lastGazette.date !== firstGazette?.date) {
+        newDates.push(lastGazette.date);
+      }
+      setMultiSelectedDates(newDates);
+    }
+  }, [activeView, gazetteData, multiSelectedDates.length]);
 
   useEffect(() => {
     const view = searchParams.get("view") || "cabinet-structure";
@@ -51,10 +102,30 @@ const Organization = ({ dateRange }) => {
     if (viewName === "department-flow") {
       params.delete("selectedDate");
       params.delete("ministry");
+
+      const firstGazette = gazetteData && gazetteData.length > 0 ? gazetteData[0] : null;
+
+      const newDates = [];
+      if (firstGazette?.date) newDates.push(firstGazette.date);
+      if (selectedDate?.date && selectedDate.date !== firstGazette?.date) newDates.push(selectedDate.date);
+      setMultiSelectedDates(newDates);
+    } else if (viewName === "cabinet-structure") {
+      if (multiSelectedDates.length > 0) {
+        // Sort dates to get the latest
+        const sorted = [...multiSelectedDates].sort();
+        const latest = sorted[sorted.length - 1];
+
+        const gazetteItem = gazetteData?.find(g => g.date === latest);
+        if (gazetteItem) {
+          dispatch(setSelectedDate(gazetteItem));
+        } else {
+          dispatch(setSelectedDate({ date: latest }));
+        }
+      }
     }
     setSearchParams(params);
   };
-  
+
   const { president } = location.state || {};
   useEffect(() => {
     if (president) {
@@ -76,34 +147,38 @@ const Organization = ({ dateRange }) => {
         </div>
       )}
 
-      {/* View Toggle */}
-      <div className="flex items-center justify-center my-3 md:my-4">
-        <div className="flex items-center bg-gray-100 rounded-lg p-1 gap-1 border border-border dark:bg-gray-900">
-          <button
-            onClick={() => toggleView("cabinet-structure")}
-            className={`px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 hover:cursor-pointer w-32 md:w-40 ${activeView === "cabinet-structure"
-              ? "bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-200 shadow-sm"
-              : "text-gray-500 dark:text-gray-400 hover:text-gray-700 hover:bg-gray-200 hover:dark:bg-gray-800 hover:dark:text-gray-200"
-              }`}
-          >
-            Cabinet Structure
-          </button>
-          <button
-            onClick={() => toggleView("department-flow")}
-            className={`px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 hover:cursor-pointer w-32 md:w-40 ${activeView === "department-flow"
-              ? "bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-200 shadow-sm"
-              : "text-gray-500 dark:text-gray-400 hover:text-gray-700 hover:bg-gray-200 hover:dark:bg-gray-800 hover:dark:text-gray-200"
-              }`}
-          >
-            Department Flow
-          </button>
-        </div>
+      {/* Gazette Timeline visible for both views */}
+      <GazetteTimeline
+        multiSelect={activeView === "department-flow"}
+        multiSelectedDates={multiSelectedDates}
+        onMultiSelectChange={handleMultiSelectChange}
+      />
+
+      {/* View Toggle Tabs (Moved below GazetteTimeline) */}
+      <div className="flex border-b border-border mt-2 mb-4 px-2 md:px-4 gap-1">
+        <button
+          onClick={() => toggleView("cabinet-structure")}
+          className={`px-4 py-2 text-sm font-medium transition-all duration-200 hover:cursor-pointer rounded-t-lg border-t border-l border-r ${activeView === "cabinet-structure"
+            ? "bg-background border-border text-foreground -mb-[1px] shadow-sm z-10"
+            : "bg-muted border-transparent text-muted-foreground hover:bg-muted/80 hover:text-foreground"
+            }`}
+        >
+          Structure
+        </button>
+        <button
+          onClick={() => toggleView("department-flow")}
+          className={`px-4 py-2 text-sm font-medium transition-all duration-200 hover:cursor-pointer rounded-t-lg border-t border-l border-r ${activeView === "department-flow"
+            ? "bg-background border-border text-foreground -mb-[1px] shadow-sm z-10"
+            : "bg-muted border-transparent text-muted-foreground hover:bg-muted/80 hover:text-foreground"
+            }`}
+        >
+          Changes
+        </button>
       </div>
 
       {/* Conditional rendering based on active view */}
       {activeView === "cabinet-structure" ? (
         <>
-          <GazetteTimeline />
           {selectedPresident && <>{selectedDate != null && <MinistryCardGrid />}</>}
         </>
       ) : (
@@ -112,6 +187,7 @@ const Organization = ({ dateRange }) => {
             key={selectedPresident?.id}
             presidentId={selectedPresident?.id}
             dateRange={dateRange}
+            selectedDates={multiSelectedDates}
             onMinistryNodeClick={handleMinistryNodeClick}
           />
         </LandscapeRequired>

--- a/src/pages/OrganizationPage/screens/Organization.jsx
+++ b/src/pages/OrganizationPage/screens/Organization.jsx
@@ -19,18 +19,32 @@ const Organization = ({ dateRange }) => {
   const location = useLocation();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const [activeView, setActiveView] = useState(searchParams.get('view') || 'cabinet-structure');
-  const [multiSelectedDates, setMultiSelectedDates] = useState([]);
-
-  const presidentRelationDict = useSelector((s) => s.presidency.presidentRelationDict);
+  const [activeView, setActiveView] = useState(searchParams.get('view') || 'structure');
+  const [multiSelectedDates, setMultiSelectedDates] = useState(() => {
+    const params = new URLSearchParams(window.location.search);
+    const datesParam = params.get('compareDates');
+    return datesParam ? datesParam.split(',') : [];
+  });
 
   const handleMultiSelectChange = useCallback((date) => {
-    setMultiSelectedDates((prev) =>
-      prev.includes(date) ? prev.filter((d) => d !== date) : [...prev, date].slice(-10) // Max 10 dates allowed
-    );
-  }, []);
+    setMultiSelectedDates((prev) => {
+      const newDates = prev.includes(date) ? prev.filter((d) => d !== date) : [...prev, date].slice(-10);
+
+      // Sync to URL
+      const params = new URLSearchParams(window.location.search);
+      if (newDates.length > 0) {
+        params.set("compareDates", newDates.join(","));
+      } else {
+        params.delete("compareDates");
+      }
+      setSearchParams(params, { replace: true });
+
+      return newDates;
+    });
+  }, [setSearchParams]);
 
   const lastResetPresidentId = useRef(null);
+  const isFirstMount = useRef(true);
 
   useEffect(() => {
     if (!selectedPresident || !gazetteData || gazetteData.length === 0) return;
@@ -38,28 +52,41 @@ const Organization = ({ dateRange }) => {
     if (lastResetPresidentId.current !== selectedPresident.id) {
       lastResetPresidentId.current = selectedPresident.id;
 
-      if (activeView === "cabinet-structure") {
+      if (activeView === "structure") {
         const lastGazette = gazetteData[gazetteData.length - 1];
         if (lastGazette) {
           dispatch(setSelectedDate(lastGazette));
         }
-      } else if (activeView === "department-flow") {
-        const firstGazette = gazetteData[0];
-        const lastGazette = gazetteData[gazetteData.length - 1];
+      } else if (activeView === "changes") {
+        const params = new URLSearchParams(window.location.search);
+        const datesFromUrl = params.get("compareDates");
 
-        const newDates = [];
-        if (firstGazette?.date) newDates.push(firstGazette.date);
-        if (lastGazette?.date && lastGazette.date !== firstGazette?.date) {
-          newDates.push(lastGazette.date);
+        if (isFirstMount.current && datesFromUrl) {
+          setMultiSelectedDates(datesFromUrl.split(","));
+        } else {
+          const firstGazette = gazetteData[0];
+          const lastGazette = gazetteData[gazetteData.length - 1];
+
+          const newDates = [];
+          if (firstGazette?.date) newDates.push(firstGazette.date);
+          if (lastGazette?.date && lastGazette.date !== firstGazette?.date) {
+            newDates.push(lastGazette.date);
+          }
+          setMultiSelectedDates(newDates);
+
+          if (newDates.length > 0) {
+            params.set("compareDates", newDates.join(","));
+            setSearchParams(params, { replace: true });
+          }
         }
-        setMultiSelectedDates(newDates);
       }
+      isFirstMount.current = false;
     }
-  }, [selectedPresident, gazetteData, activeView, dispatch]);
+  }, [selectedPresident, gazetteData, activeView, dispatch, setSearchParams]);
 
   // Aggressive fallback to ensure the timeline always has defaults on refresh or when cleared in Changes tab
   useEffect(() => {
-    if (activeView === "department-flow" && multiSelectedDates.length === 0 && gazetteData?.length > 0) {
+    if (activeView === "changes" && multiSelectedDates.length === 0 && gazetteData?.length > 0) {
       const firstGazette = gazetteData[0];
       const lastGazette = gazetteData[gazetteData.length - 1];
 
@@ -73,10 +100,10 @@ const Organization = ({ dateRange }) => {
   }, [activeView, gazetteData, multiSelectedDates.length]);
 
   useEffect(() => {
-    const view = searchParams.get("view") || "cabinet-structure";
+    const view = searchParams.get("view") || "structure";
     setActiveView(view);
 
-    if (view === "department-flow" && (searchParams.has("selectedDate") || searchParams.has("ministry"))) {
+    if (view === "changes" && (searchParams.has("selectedDate") || searchParams.has("ministry"))) {
       const params = new URLSearchParams(window.location.search);
       params.delete("selectedDate");
       params.delete("ministry");
@@ -88,18 +115,19 @@ const Organization = ({ dateRange }) => {
     const resolvedDate = resolveGazetteDate(node.time, gazetteData);
     dispatch(setSelectedDate({ date: resolvedDate }));
     const params = new URLSearchParams(window.location.search);
-    params.set("view", "cabinet-structure");
+    params.delete("compareDates");
+    params.set("view", "structure");
     params.set("selectedDate", resolvedDate);
     params.set("ministry", node.id);
     setSearchParams(params);
-    setActiveView("cabinet-structure");
+    setActiveView("structure");
   }, [dispatch, setSearchParams, gazetteData]);
 
   const toggleView = (viewName) => {
     setActiveView(viewName);
     const params = new URLSearchParams(window.location.search);
     params.set("view", viewName);
-    if (viewName === "department-flow") {
+    if (viewName === "changes") {
       params.delete("selectedDate");
       params.delete("ministry");
 
@@ -109,7 +137,14 @@ const Organization = ({ dateRange }) => {
       if (firstGazette?.date) newDates.push(firstGazette.date);
       if (selectedDate?.date && selectedDate.date !== firstGazette?.date) newDates.push(selectedDate.date);
       setMultiSelectedDates(newDates);
-    } else if (viewName === "cabinet-structure") {
+
+      if (newDates.length > 0) {
+        params.set("compareDates", newDates.join(","));
+      } else {
+        params.delete("compareDates");
+      }
+    } else if (viewName === "structure") {
+      params.delete("compareDates");
       if (multiSelectedDates.length > 0) {
         // Sort dates to get the latest
         const sorted = [...multiSelectedDates].sort();
@@ -150,7 +185,7 @@ const Organization = ({ dateRange }) => {
       {/* Gazette Timeline (Moved outside the white box) */}
       <div className="px-2 md:px-4">
         <GazetteTimeline
-          multiSelect={activeView === "department-flow"}
+          multiSelect={activeView === "changes"}
           multiSelectedDates={multiSelectedDates}
           onMultiSelectChange={handleMultiSelectChange}
         />
@@ -161,38 +196,38 @@ const Organization = ({ dateRange }) => {
         {/* View Toggle Tabs */}
         <div className="flex items-end border-b border-border mb-4 gap-2 px-2">
           <button
-            onClick={() => toggleView("cabinet-structure")}
-            className={`min-w-[140px] md:min-w-[160px] px-6 py-2.5 text-sm font-semibold transition-all duration-200 hover:cursor-pointer rounded-t-xl border-t border-l border-r relative ${activeView === "cabinet-structure"
+            onClick={() => toggleView("structure")}
+            className={`min-w-[140px] md:min-w-[160px] px-6 py-2.5 text-sm font-semibold transition-all duration-200 hover:cursor-pointer rounded-t-xl border-t border-l border-r relative ${activeView === "structure"
               ? "bg-card border-border text-primary"
               : "bg-muted border-transparent text-primary/60 hover:bg-muted/80 hover:text-primary"
               }`}
           >
             Structure
-            {activeView === "cabinet-structure" && (
+            {activeView === "structure" && (
               <div className="absolute -bottom-[1px] left-0 right-0 h-[2px] bg-card" />
             )}
           </button>
           <button
-            onClick={() => toggleView("department-flow")}
-            className={`min-w-[140px] md:min-w-[160px] px-6 py-2.5 text-sm font-semibold transition-all duration-200 hover:cursor-pointer rounded-t-xl border-t border-l border-r relative ${activeView === "department-flow"
+            onClick={() => toggleView("changes")}
+            className={`min-w-[140px] md:min-w-[160px] px-6 py-2.5 text-sm font-semibold transition-all duration-200 hover:cursor-pointer rounded-t-xl border-t border-l border-r relative ${activeView === "changes"
               ? "bg-card border-border text-primary"
               : "bg-muted border-transparent text-primary/60 hover:bg-muted/80 hover:text-primary"
               }`}
           >
             Changes
-            {activeView === "department-flow" && (
+            {activeView === "changes" && (
               <div className="absolute -bottom-[1px] left-0 right-0 h-[2px] bg-card" />
             )}
           </button>
         </div>
 
         {/* Conditional rendering based on active view */}
-        {activeView === "cabinet-structure" ? (
+        {activeView === "structure" ? (
           <>
             {selectedPresident && <>{selectedDate != null && <MinistryCardGrid />}</>}
           </>
         ) : (
-          <LandscapeRequired onBack={() => toggleView("cabinet-structure")}>
+          <LandscapeRequired onBack={() => toggleView("structure")}>
             <CabinetFlow
               key={selectedPresident?.id}
               presidentId={selectedPresident?.id}

--- a/src/pages/cabinetFlowPage/components/CabinetFlowPanel.jsx
+++ b/src/pages/cabinetFlowPage/components/CabinetFlowPanel.jsx
@@ -4,7 +4,7 @@ import SankeyChart from "./SankeyChart";
 import { BarChart2 } from "lucide-react";
 import { useThemeContext } from "../../../context/themeContext";
 
-const CabinetFlowPanel = ({ presidentId, dates, onNodeClick, onNodeNavigate, onLinkClick, onLinkSingleClick, onClearSelection, selectedLink, selectedNode }) => {
+const CabinetFlowPanel = ({ presidentId, dates, onNodeClick, onNodeNavigate, onLinkClick, onClearSelection, selectedLink, selectedNode }) => {
     const { isDark } = useThemeContext();
     const containerRef = useRef(null);
     const [containerWidth, setContainerWidth] = useState(0);
@@ -78,7 +78,6 @@ const CabinetFlowPanel = ({ presidentId, dates, onNodeClick, onNodeNavigate, onL
                     onNodeClick={onNodeClick}
                     onNodeNavigate={onNodeNavigate}
                     onLinkClick={onLinkClick}
-                    onLinkSingleClick={onLinkSingleClick}
                     onClearSelection={onClearSelection}
                     selectedLink={selectedLink}
                     selectedNode={selectedNode}

--- a/src/pages/cabinetFlowPage/components/DateRangePicker.jsx
+++ b/src/pages/cabinetFlowPage/components/DateRangePicker.jsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { Calendar, ChevronLeft } from "lucide-react";
 
-const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, maxDates = 3, gazetteDates }) => {
+const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, gazetteDates }) => {
     const [isOpen, setIsOpen] = useState(false);
 
     const datePickerRef = useRef(null);
@@ -41,7 +41,7 @@ const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, maxDates
 
     const isInRange = (d) => allDatesSet.has(d);
     const isSelected = (d) => selectedDates.includes(d);
-    const isDisabled = (d) => !isSelected(d) && selectedDates.length >= maxDates;
+    const isDisabled = () => false;
     const isEdge = (d) => d === startDate || d === endDate;
 
     const daysInMonth = new Date(viewMonth.year, viewMonth.month + 1, 0).getDate();
@@ -78,7 +78,7 @@ const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, maxDates
 
     const triggerLabel =
         selectedDates.length === 0
-            ? "Select up to 3 dates"
+            ? "Select dates"
             : selectedDates.length === 1
                 ? selectedDates[0]
                 : `${selectedDates.length} dates selected`;
@@ -94,7 +94,7 @@ const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, maxDates
                 <span>{triggerLabel}</span>
                 {selectedDates.length > 0 && (
                     <span className="ml-1 px-1.5 py-0.5 rounded-full bg-accent/10 text-accent text-xs font-semibold">
-                        {selectedDates.length}/{maxDates}
+                        {selectedDates.length}
                     </span>
                 )}
                 <ChevronLeft
@@ -181,7 +181,7 @@ const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, maxDates
                     {/* Footer */}
                     <div className="mt-3 pt-3 border-t border-border flex items-center justify-between">
                         <p className="text-xs text-gray-400">
-                            <span className="font-semibold text-accent">{selectedDates.length}</span>/{maxDates} selected
+                            <span className="font-semibold text-accent">{selectedDates.length}</span> selected
                         </p>
                         <div className="flex gap-2">
                             {selectedDates.length > 0 && (

--- a/src/pages/cabinetFlowPage/components/DateRangePicker.jsx
+++ b/src/pages/cabinetFlowPage/components/DateRangePicker.jsx
@@ -1,6 +1,8 @@
 import { useState, useRef, useEffect } from "react";
 import { Calendar, ChevronLeft } from "lucide-react";
 
+const MAX_DATES = 10;
+
 const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, gazetteDates }) => {
     const [isOpen, setIsOpen] = useState(false);
 
@@ -41,7 +43,7 @@ const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, gazetteD
 
     const isInRange = (d) => allDatesSet.has(d);
     const isSelected = (d) => selectedDates.includes(d);
-    const isDisabled = () => false;
+    const isDisabled = (d) => !isSelected(d) && selectedDates.length >= MAX_DATES;
     const isEdge = (d) => d === startDate || d === endDate;
 
     const daysInMonth = new Date(viewMonth.year, viewMonth.month + 1, 0).getDate();
@@ -78,7 +80,7 @@ const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, gazetteD
 
     const triggerLabel =
         selectedDates.length === 0
-            ? "Select dates"
+            ? `Select up to ${MAX_DATES} dates`
             : selectedDates.length === 1
                 ? selectedDates[0]
                 : `${selectedDates.length} dates selected`;
@@ -94,7 +96,7 @@ const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, gazetteD
                 <span>{triggerLabel}</span>
                 {selectedDates.length > 0 && (
                     <span className="ml-1 px-1.5 py-0.5 rounded-full bg-accent/10 text-accent text-xs font-semibold">
-                        {selectedDates.length}
+                        {selectedDates.length}/{MAX_DATES}
                     </span>
                 )}
                 <ChevronLeft
@@ -181,7 +183,7 @@ const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, gazetteD
                     {/* Footer */}
                     <div className="mt-3 pt-3 border-t border-border flex items-center justify-between">
                         <p className="text-xs text-gray-400">
-                            <span className="font-semibold text-accent">{selectedDates.length}</span> selected
+                            <span className="font-semibold text-accent">{selectedDates.length}</span>/{MAX_DATES} selected
                         </p>
                         <div className="flex gap-2">
                             {selectedDates.length > 0 && (

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -2,7 +2,7 @@ import * as d3 from "d3";
 import { sankey, sankeyLinkHorizontal } from "d3-sankey";
 import { useEffect, useRef } from "react";
 
-export default function SankeyChart({ data, width, height, isDarkMode, onNodeClick, onNodeNavigate, onLinkClick, onLinkSingleClick, onClearSelection, selectedLink, selectedNode }) {
+export default function SankeyChart({ data, width, height, isDarkMode, onNodeClick, onNodeNavigate, onLinkClick, onClearSelection, selectedLink, selectedNode }) {
   const containerRef = useRef();
   const svgRef = useRef();
 
@@ -150,7 +150,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .attr("offset", "100%")
       .attr("stop-color", (d) => color(d.target.id));
 
-    // Tooltip — pinned next to the hovered link's nodes, not the cursor
+    // Tooltip — pinned next to the hovered/clicked link's nodes, not the cursor
     const tooltip = container
       .append("div")
       .attr("class", "sankey-tooltip")
@@ -172,10 +172,9 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
 
     // Hovering the link or the tooltip itself keeps it open; leaving both hides it
     let hideTimer = null;
-    let activeLinkData = null;
 
-    // Pins the tooltip right where the cursor entered the link, once — it
-    // does NOT track mousemove afterwards, so it stays put under the cursor
+    // Pins the tooltip right where the cursor entered/clicked the link, once —
+    // it does NOT track mousemove afterwards, so it stays put under the cursor
     // instead of requiring the user to travel to find it.
     const positionTooltipAtCursor = (event) => {
       const containerRect = containerRef.current.getBoundingClientRect();
@@ -214,7 +213,6 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
         clearTimeout(hideTimer);
         hideTimer = null;
       }
-      activeLinkData = d;
       tooltip
         .style("pointer-events", "auto")
         .html(`
@@ -222,10 +220,6 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
             <strong>${d.source.name}</strong> → <strong>${d.target.name}</strong><br/>
             ${d.value} department${d.value > 1 ? "s" : ""} moved
           </div>
-          ${onLinkClick
-            ? `<button type="button" class="sankey-tooltip-link text-accent" style="margin-top:6px;display:inline-block;background:none;border:none;padding:0;font-size:12px;font-weight:600;text-decoration:underline;cursor:pointer;">View departments moved</button>`
-            : ""
-          }
         `);
 
       positionTooltipAtCursor(event);
@@ -250,13 +244,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
           hideTimer = null;
         }
       })
-      .on("mouseleave", hideTooltipDelayed)
-      .on("click", (event) => {
-        event.stopPropagation();
-        if (event.target.closest(".sankey-tooltip-link") && activeLinkData) {
-          onLinkClick?.(activeLinkData);
-        }
-      });
+      .on("mouseleave", hideTooltipDelayed);
 
     // Links
     svg
@@ -270,7 +258,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .attr("stroke", (d, i) => (isHighlighted(d) || !hasActiveSelection ? `url(#gradient-${i})` : greyColor))
       .attr("stroke-opacity", restingOpacity)
       .attr("stroke-width", (d) => Math.max(1, d.width))
-      .style("cursor", onLinkSingleClick ? "pointer" : "default")
+      .style("cursor", onLinkClick ? "pointer" : "default")
       .on("mouseover", (event, d) => {
         const link = d3.select(event.target).transition().duration(200).attr("stroke-opacity", 0.9);
         if (!isHighlighted(d) && hasActiveSelection) {
@@ -287,7 +275,8 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       })
       .on("click", (event, d) => {
         event.stopPropagation();
-        onLinkSingleClick?.(d.source);
+        showTooltip(d, event);
+        onLinkClick?.(d);
       });
 
     // Column date labels
@@ -391,7 +380,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       if (hideTimer) clearTimeout(hideTimer);
       tooltip.remove();
     };
-  }, [data, width, height, isDarkMode, onNodeClick, onNodeNavigate, onLinkClick, onLinkSingleClick, onClearSelection, selectedLink, selectedNode]);
+  }, [data, width, height, isDarkMode, onNodeClick, onNodeNavigate, onLinkClick, onClearSelection, selectedLink, selectedNode]);
 
   return (
     <div ref={containerRef} style={{ position: "relative", overflow: "hidden" }}>

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -173,9 +173,8 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
     // Hovering the link or the tooltip itself keeps it open; leaving both hides it
     let hideTimer = null;
 
-    // Pins the tooltip right where the cursor entered/clicked the link, once —
-    // it does NOT track mousemove afterwards, so it stays put under the cursor
-    // instead of requiring the user to travel to find it.
+    // Repositions the tooltip relative to the current cursor position so it
+    // tracks the mouse while hovering a link.
     const positionTooltipAtCursor = (event) => {
       const containerRect = containerRef.current.getBoundingClientRect();
       const tooltipNode = tooltip.node();
@@ -265,6 +264,9 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
           link.attr("stroke", greyColorHover);
         }
         showTooltip(d, event);
+      })
+      .on("mousemove", (event) => {
+        positionTooltipAtCursor(event);
       })
       .on("mouseout", (event, d) => {
         const link = d3.select(event.target).transition().duration(200).attr("stroke-opacity", restingOpacity(d));

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -21,8 +21,9 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
 
     const container = d3.select(containerRef.current);
 
-    // Clear any existing SVG content
+    // Clear any existing SVG content & tooltips
     d3.select(svgRef.current).selectAll("*").remove();
+    container.selectAll(".sankey-tooltip").remove();
 
     const svg = d3
       .select(svgRef.current)
@@ -149,6 +150,114 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .attr("offset", "100%")
       .attr("stop-color", (d) => color(d.target.id));
 
+    // Tooltip — pinned next to the hovered link's nodes, not the cursor
+    const tooltip = container
+      .append("div")
+      .attr("class", "sankey-tooltip")
+      .style("position", "absolute")
+      .style("background", "rgba(0, 0, 0, 0.85)")
+      .style("color", "#fff")
+      .style("padding", "8px 10px")
+      .style("border-radius", "4px")
+      .style("font-size", "12px")
+      .style("pointer-events", "none")
+      .style("opacity", 0)
+      // FIX: constrain width so it never exceeds the container
+      .style("max-width", "min(260px, 80%)")
+      .style("word-wrap", "break-word")
+      .style("white-space", "normal")
+      .style("line-height", "1.5")
+      // Prevent the tooltip itself from causing the container to grow
+      .style("box-sizing", "border-box");
+
+    // Hovering the link or the tooltip itself keeps it open; leaving both hides it
+    let hideTimer = null;
+    let activeLinkData = null;
+
+    // Pins the tooltip right where the cursor entered the link, once — it
+    // does NOT track mousemove afterwards, so it stays put under the cursor
+    // instead of requiring the user to travel to find it.
+    const positionTooltipAtCursor = (event) => {
+      const containerRect = containerRef.current.getBoundingClientRect();
+      const tooltipNode = tooltip.node();
+      const tooltipWidth = tooltipNode.offsetWidth;
+      const tooltipHeight = tooltipNode.offsetHeight;
+      const MARGIN = 8;
+
+      // The chart container can be taller/wider than the actual browser
+      // viewport (e.g. a tall chart with many nodes), so clamp against
+      // both the container's own box AND the visible viewport — in
+      // container-local coordinates — and use whichever is tighter.
+      const minX = Math.max(0, -containerRect.left) + MARGIN;
+      const maxX = Math.min(containerRect.width, window.innerWidth - containerRect.left) - tooltipWidth - MARGIN;
+      const minY = Math.max(0, -containerRect.top) + MARGIN;
+      const maxY = Math.min(containerRect.height, window.innerHeight - containerRect.top) - tooltipHeight - MARGIN;
+
+      let x = event.clientX - containerRect.left + 12;
+      let y = event.clientY - containerRect.top + 12;
+
+      if (x > maxX) {
+        x = event.clientX - containerRect.left - tooltipWidth - 12;
+      }
+      x = Math.min(Math.max(x, minX), maxX);
+
+      if (y > maxY) {
+        y = event.clientY - containerRect.top - tooltipHeight - 12;
+      }
+      y = Math.min(Math.max(y, minY), maxY);
+
+      tooltip.style("left", `${x}px`).style("top", `${y}px`);
+    };
+
+    const showTooltip = (d, event) => {
+      if (hideTimer) {
+        clearTimeout(hideTimer);
+        hideTimer = null;
+      }
+      activeLinkData = d;
+      tooltip
+        .style("pointer-events", "auto")
+        .html(`
+          <div>
+            <strong>${d.source.name}</strong> → <strong>${d.target.name}</strong><br/>
+            ${d.value} department${d.value > 1 ? "s" : ""} moved
+          </div>
+          ${onLinkClick
+            ? `<button type="button" class="sankey-tooltip-link text-accent" style="margin-top:6px;display:inline-block;background:none;border:none;padding:0;font-size:12px;font-weight:600;text-decoration:underline;cursor:pointer;">View departments moved</button>`
+            : ""
+          }
+        `);
+
+      positionTooltipAtCursor(event);
+
+      tooltip.transition().duration(200).style("opacity", 1);
+    };
+
+    const hideTooltipDelayed = () => {
+      hideTimer = setTimeout(() => {
+        tooltip
+          .transition()
+          .duration(200)
+          .style("opacity", 0)
+          .on("end", () => tooltip.style("pointer-events", "none"));
+      }, 150);
+    };
+
+    tooltip
+      .on("mouseenter", () => {
+        if (hideTimer) {
+          clearTimeout(hideTimer);
+          hideTimer = null;
+        }
+      })
+      .on("mouseleave", hideTooltipDelayed)
+      .on("click", (event) => {
+        event.stopPropagation();
+        if (event.target.closest(".sankey-tooltip-link") && activeLinkData) {
+          onLinkClick?.(activeLinkData);
+        }
+      });
+
     // Links
     svg
       .append("g")
@@ -161,22 +270,24 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .attr("stroke", (d, i) => (isHighlighted(d) || !hasActiveSelection ? `url(#gradient-${i})` : greyColor))
       .attr("stroke-opacity", restingOpacity)
       .attr("stroke-width", (d) => Math.max(1, d.width))
-      .style("cursor", onLinkClick ? "pointer" : "default")
+      .style("cursor", onLinkSingleClick ? "pointer" : "default")
       .on("mouseover", (event, d) => {
         const link = d3.select(event.target).transition().duration(200).attr("stroke-opacity", 0.9);
         if (!isHighlighted(d) && hasActiveSelection) {
           link.attr("stroke", greyColorHover);
         }
+        showTooltip(d, event);
       })
       .on("mouseout", (event, d) => {
         const link = d3.select(event.target).transition().duration(200).attr("stroke-opacity", restingOpacity(d));
         if (!isHighlighted(d) && hasActiveSelection) {
           link.attr("stroke", greyColor);
         }
+        hideTooltipDelayed();
       })
       .on("click", (event, d) => {
         event.stopPropagation();
-        onLinkClick?.(d);
+        onLinkSingleClick?.(d.source);
       });
 
     // Column date labels
@@ -277,6 +388,8 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       });
 
     return () => {
+      if (hideTimer) clearTimeout(hideTimer);
+      tooltip.remove();
     };
   }, [data, width, height, isDarkMode, onNodeClick, onNodeNavigate, onLinkClick, onLinkSingleClick, onClearSelection, selectedLink, selectedNode]);
 

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -81,18 +81,19 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
         // 2 column layout: split the single gap 50/50 between both columns
         const gap = layerBounds[1].x0 - layerBounds[0].x1;
         availablePx = gap / 2 - LABEL_PADDING;
+      } else if (layer === 0) {
+        // first column: label renders to the right, full gap to the next column is free
+        const nextX0 = layerBounds[1]?.x0 ?? width;
+        availablePx = nextX0 - layerBounds[0].x1 - LABEL_PADDING;
+      } else if (layer === totalLayers - 1) {
+        // last column: label renders to the left, full gap to the previous column is free
+        const prevX1 = layerBounds[layer - 1]?.x1 ?? 0;
+        availablePx = layerBounds[layer].x0 - prevX1 - LABEL_PADDING;
       } else {
-        // 3 column layout:
-        // for col 1 -> full gaap to col 2
-        // for col 2 to col 3 -> split the gap by 50/50 and use for both col 2 and col 3
-        if (layer === 0) {
-          const nextX0 = layerBounds[1]?.x0 ?? width;
-          availablePx = nextX0 - layerBounds[0].x1 - LABEL_PADDING;
-        } else {
-          const prevX1 = layerBounds[layer - 1]?.x1 ?? 0;
-          const gap = layerBounds[layer].x0 - prevX1;
-          availablePx = gap / 2 - LABEL_PADDING;
-        }
+        // middle columns: split the gap to the previous column 50/50
+        const prevX1 = layerBounds[layer - 1]?.x1 ?? 0;
+        const gap = layerBounds[layer].x0 - prevX1;
+        availablePx = gap / 2 - LABEL_PADDING;
       }
 
       return Math.max(8, Math.floor(availablePx / CHAR_WIDTH_PX));

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -277,8 +277,12 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       })
       .on("click", (event, d) => {
         event.stopPropagation();
-        showTooltip(d, event);
-        onLinkClick?.(d);
+        if (isSelectedLink(d)) {
+          onClearSelection?.();
+        } else {
+          showTooltip(d, event);
+          onLinkClick?.(d);
+        }
       });
 
     // Column date labels

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -19,11 +19,8 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
     const parseDate = d3.utcParse("%Y-%m-%d");
     const formatDate = d3.utcFormat("%b %d %Y");
 
-    const container = d3.select(containerRef.current);
-
-    // Clear any existing SVG content & tooltips
+    // Clear any existing SVG content
     d3.select(svgRef.current).selectAll("*").remove();
-    container.selectAll(".sankey-tooltip").remove();
 
     const svg = d3
       .select(svgRef.current)
@@ -150,101 +147,6 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .attr("offset", "100%")
       .attr("stop-color", (d) => color(d.target.id));
 
-    // Tooltip — pinned next to the hovered/clicked link's nodes, not the cursor
-    const tooltip = container
-      .append("div")
-      .attr("class", "sankey-tooltip")
-      .style("position", "absolute")
-      .style("background", "rgba(0, 0, 0, 0.85)")
-      .style("color", "#fff")
-      .style("padding", "8px 10px")
-      .style("border-radius", "4px")
-      .style("font-size", "12px")
-      .style("pointer-events", "none")
-      .style("opacity", 0)
-      // FIX: constrain width so it never exceeds the container
-      .style("max-width", "min(260px, 80%)")
-      .style("word-wrap", "break-word")
-      .style("white-space", "normal")
-      .style("line-height", "1.5")
-      // Prevent the tooltip itself from causing the container to grow
-      .style("box-sizing", "border-box");
-
-    // Hovering the link or the tooltip itself keeps it open; leaving both hides it
-    let hideTimer = null;
-
-    // Repositions the tooltip relative to the current cursor position so it
-    // tracks the mouse while hovering a link.
-    const positionTooltipAtCursor = (event) => {
-      const containerRect = containerRef.current.getBoundingClientRect();
-      const tooltipNode = tooltip.node();
-      const tooltipWidth = tooltipNode.offsetWidth;
-      const tooltipHeight = tooltipNode.offsetHeight;
-      const MARGIN = 8;
-
-      // The chart container can be taller/wider than the actual browser
-      // viewport (e.g. a tall chart with many nodes), so clamp against
-      // both the container's own box AND the visible viewport — in
-      // container-local coordinates — and use whichever is tighter.
-      const minX = Math.max(0, -containerRect.left) + MARGIN;
-      const maxX = Math.min(containerRect.width, window.innerWidth - containerRect.left) - tooltipWidth - MARGIN;
-      const minY = Math.max(0, -containerRect.top) + MARGIN;
-      const maxY = Math.min(containerRect.height, window.innerHeight - containerRect.top) - tooltipHeight - MARGIN;
-
-      let x = event.clientX - containerRect.left + 12;
-      let y = event.clientY - containerRect.top + 12;
-
-      if (x > maxX) {
-        x = event.clientX - containerRect.left - tooltipWidth - 12;
-      }
-      x = Math.min(Math.max(x, minX), maxX);
-
-      if (y > maxY) {
-        y = event.clientY - containerRect.top - tooltipHeight - 12;
-      }
-      y = Math.min(Math.max(y, minY), maxY);
-
-      tooltip.style("left", `${x}px`).style("top", `${y}px`);
-    };
-
-    const showTooltip = (d, event) => {
-      if (hideTimer) {
-        clearTimeout(hideTimer);
-        hideTimer = null;
-      }
-      tooltip
-        .style("pointer-events", "auto")
-        .html(`
-          <div>
-            <strong>${d.source.name}</strong> → <strong>${d.target.name}</strong><br/>
-            ${d.value} department${d.value > 1 ? "s" : ""} moved
-          </div>
-        `);
-
-      positionTooltipAtCursor(event);
-
-      tooltip.transition().duration(200).style("opacity", 1);
-    };
-
-    const hideTooltipDelayed = () => {
-      hideTimer = setTimeout(() => {
-        tooltip
-          .transition()
-          .duration(200)
-          .style("opacity", 0)
-          .on("end", () => tooltip.style("pointer-events", "none"));
-      }, 150);
-    };
-
-    tooltip
-      .on("mouseenter", () => {
-        if (hideTimer) {
-          clearTimeout(hideTimer);
-          hideTimer = null;
-        }
-      })
-      .on("mouseleave", hideTooltipDelayed);
-
     // Links
     svg
       .append("g")
@@ -263,22 +165,20 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
         if (!isHighlighted(d) && hasActiveSelection) {
           link.attr("stroke", greyColorHover);
         }
-        showTooltip(d, event);
-      })
-      .on("mousemove", (event) => {
-        positionTooltipAtCursor(event);
       })
       .on("mouseout", (event, d) => {
         const link = d3.select(event.target).transition().duration(200).attr("stroke-opacity", restingOpacity(d));
         if (!isHighlighted(d) && hasActiveSelection) {
           link.attr("stroke", greyColor);
         }
-        hideTooltipDelayed();
       })
       .on("click", (event, d) => {
         event.stopPropagation();
-        showTooltip(d, event);
-        onLinkClick?.(d);
+        if (isSelectedLink(d)) {
+          onClearSelection?.();
+        } else {
+          onLinkClick?.(d);
+        }
       });
 
     // Column date labels
@@ -377,11 +277,6 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .on("mouseleave", function () {
         d3.select(this).style("text-decoration", null);
       });
-
-    return () => {
-      if (hideTimer) clearTimeout(hideTimer);
-      tooltip.remove();
-    };
   }, [data, width, height, isDarkMode, onNodeClick, onNodeNavigate, onLinkClick, onClearSelection, selectedLink, selectedNode]);
 
   return (

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -19,8 +19,11 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
     const parseDate = d3.utcParse("%Y-%m-%d");
     const formatDate = d3.utcFormat("%b %d %Y");
 
-    // Clear any existing SVG content
+    const container = d3.select(containerRef.current);
+
+    // Clear any existing SVG content & tooltips
     d3.select(svgRef.current).selectAll("*").remove();
+    container.selectAll(".sankey-tooltip").remove();
 
     const svg = d3
       .select(svgRef.current)
@@ -147,6 +150,101 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .attr("offset", "100%")
       .attr("stop-color", (d) => color(d.target.id));
 
+    // Tooltip — pinned next to the hovered/clicked link's nodes, not the cursor
+    const tooltip = container
+      .append("div")
+      .attr("class", "sankey-tooltip")
+      .style("position", "absolute")
+      .style("background", "rgba(0, 0, 0, 0.85)")
+      .style("color", "#fff")
+      .style("padding", "8px 10px")
+      .style("border-radius", "4px")
+      .style("font-size", "12px")
+      .style("pointer-events", "none")
+      .style("opacity", 0)
+      // FIX: constrain width so it never exceeds the container
+      .style("max-width", "min(260px, 80%)")
+      .style("word-wrap", "break-word")
+      .style("white-space", "normal")
+      .style("line-height", "1.5")
+      // Prevent the tooltip itself from causing the container to grow
+      .style("box-sizing", "border-box");
+
+    // Hovering the link or the tooltip itself keeps it open; leaving both hides it
+    let hideTimer = null;
+
+    // Repositions the tooltip relative to the current cursor position so it
+    // tracks the mouse while hovering a link.
+    const positionTooltipAtCursor = (event) => {
+      const containerRect = containerRef.current.getBoundingClientRect();
+      const tooltipNode = tooltip.node();
+      const tooltipWidth = tooltipNode.offsetWidth;
+      const tooltipHeight = tooltipNode.offsetHeight;
+      const MARGIN = 8;
+
+      // The chart container can be taller/wider than the actual browser
+      // viewport (e.g. a tall chart with many nodes), so clamp against
+      // both the container's own box AND the visible viewport — in
+      // container-local coordinates — and use whichever is tighter.
+      const minX = Math.max(0, -containerRect.left) + MARGIN;
+      const maxX = Math.min(containerRect.width, window.innerWidth - containerRect.left) - tooltipWidth - MARGIN;
+      const minY = Math.max(0, -containerRect.top) + MARGIN;
+      const maxY = Math.min(containerRect.height, window.innerHeight - containerRect.top) - tooltipHeight - MARGIN;
+
+      let x = event.clientX - containerRect.left + 12;
+      let y = event.clientY - containerRect.top + 12;
+
+      if (x > maxX) {
+        x = event.clientX - containerRect.left - tooltipWidth - 12;
+      }
+      x = Math.min(Math.max(x, minX), maxX);
+
+      if (y > maxY) {
+        y = event.clientY - containerRect.top - tooltipHeight - 12;
+      }
+      y = Math.min(Math.max(y, minY), maxY);
+
+      tooltip.style("left", `${x}px`).style("top", `${y}px`);
+    };
+
+    const showTooltip = (d, event) => {
+      if (hideTimer) {
+        clearTimeout(hideTimer);
+        hideTimer = null;
+      }
+      tooltip
+        .style("pointer-events", "auto")
+        .html(`
+          <div>
+            <strong>${d.source.name}</strong> → <strong>${d.target.name}</strong><br/>
+            ${d.value} department${d.value > 1 ? "s" : ""} moved
+          </div>
+        `);
+
+      positionTooltipAtCursor(event);
+
+      tooltip.transition().duration(200).style("opacity", 1);
+    };
+
+    const hideTooltipDelayed = () => {
+      hideTimer = setTimeout(() => {
+        tooltip
+          .transition()
+          .duration(200)
+          .style("opacity", 0)
+          .on("end", () => tooltip.style("pointer-events", "none"));
+      }, 150);
+    };
+
+    tooltip
+      .on("mouseenter", () => {
+        if (hideTimer) {
+          clearTimeout(hideTimer);
+          hideTimer = null;
+        }
+      })
+      .on("mouseleave", hideTooltipDelayed);
+
     // Links
     svg
       .append("g")
@@ -165,20 +263,22 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
         if (!isHighlighted(d) && hasActiveSelection) {
           link.attr("stroke", greyColorHover);
         }
+        showTooltip(d, event);
+      })
+      .on("mousemove", (event) => {
+        positionTooltipAtCursor(event);
       })
       .on("mouseout", (event, d) => {
         const link = d3.select(event.target).transition().duration(200).attr("stroke-opacity", restingOpacity(d));
         if (!isHighlighted(d) && hasActiveSelection) {
           link.attr("stroke", greyColor);
         }
+        hideTooltipDelayed();
       })
       .on("click", (event, d) => {
         event.stopPropagation();
-        if (isSelectedLink(d)) {
-          onClearSelection?.();
-        } else {
-          onLinkClick?.(d);
-        }
+        showTooltip(d, event);
+        onLinkClick?.(d);
       });
 
     // Column date labels
@@ -277,6 +377,11 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .on("mouseleave", function () {
         d3.select(this).style("text-decoration", null);
       });
+
+    return () => {
+      if (hideTimer) clearTimeout(hideTimer);
+      tooltip.remove();
+    };
   }, [data, width, height, isDarkMode, onNodeClick, onNodeNavigate, onLinkClick, onClearSelection, selectedLink, selectedNode]);
 
   return (

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -21,9 +21,8 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
 
     const container = d3.select(containerRef.current);
 
-    // Clear any existing SVG content & tooltips
+    // Clear any existing SVG content
     d3.select(svgRef.current).selectAll("*").remove();
-    container.selectAll(".sankey-tooltip").remove();
 
     const svg = d3
       .select(svgRef.current)
@@ -150,114 +149,6 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .attr("offset", "100%")
       .attr("stop-color", (d) => color(d.target.id));
 
-    // Tooltip — pinned next to the hovered link's nodes, not the cursor
-    const tooltip = container
-      .append("div")
-      .attr("class", "sankey-tooltip")
-      .style("position", "absolute")
-      .style("background", "rgba(0, 0, 0, 0.85)")
-      .style("color", "#fff")
-      .style("padding", "8px 10px")
-      .style("border-radius", "4px")
-      .style("font-size", "12px")
-      .style("pointer-events", "none")
-      .style("opacity", 0)
-      // FIX: constrain width so it never exceeds the container
-      .style("max-width", "min(260px, 80%)")
-      .style("word-wrap", "break-word")
-      .style("white-space", "normal")
-      .style("line-height", "1.5")
-      // Prevent the tooltip itself from causing the container to grow
-      .style("box-sizing", "border-box");
-
-    // Hovering the link or the tooltip itself keeps it open; leaving both hides it
-    let hideTimer = null;
-    let activeLinkData = null;
-
-    // Pins the tooltip right where the cursor entered the link, once — it
-    // does NOT track mousemove afterwards, so it stays put under the cursor
-    // instead of requiring the user to travel to find it.
-    const positionTooltipAtCursor = (event) => {
-      const containerRect = containerRef.current.getBoundingClientRect();
-      const tooltipNode = tooltip.node();
-      const tooltipWidth = tooltipNode.offsetWidth;
-      const tooltipHeight = tooltipNode.offsetHeight;
-      const MARGIN = 8;
-
-      // The chart container can be taller/wider than the actual browser
-      // viewport (e.g. a tall chart with many nodes), so clamp against
-      // both the container's own box AND the visible viewport — in
-      // container-local coordinates — and use whichever is tighter.
-      const minX = Math.max(0, -containerRect.left) + MARGIN;
-      const maxX = Math.min(containerRect.width, window.innerWidth - containerRect.left) - tooltipWidth - MARGIN;
-      const minY = Math.max(0, -containerRect.top) + MARGIN;
-      const maxY = Math.min(containerRect.height, window.innerHeight - containerRect.top) - tooltipHeight - MARGIN;
-
-      let x = event.clientX - containerRect.left + 12;
-      let y = event.clientY - containerRect.top + 12;
-
-      if (x > maxX) {
-        x = event.clientX - containerRect.left - tooltipWidth - 12;
-      }
-      x = Math.min(Math.max(x, minX), maxX);
-
-      if (y > maxY) {
-        y = event.clientY - containerRect.top - tooltipHeight - 12;
-      }
-      y = Math.min(Math.max(y, minY), maxY);
-
-      tooltip.style("left", `${x}px`).style("top", `${y}px`);
-    };
-
-    const showTooltip = (d, event) => {
-      if (hideTimer) {
-        clearTimeout(hideTimer);
-        hideTimer = null;
-      }
-      activeLinkData = d;
-      tooltip
-        .style("pointer-events", "auto")
-        .html(`
-          <div>
-            <strong>${d.source.name}</strong> → <strong>${d.target.name}</strong><br/>
-            ${d.value} department${d.value > 1 ? "s" : ""} moved
-          </div>
-          ${onLinkClick
-            ? `<button type="button" class="sankey-tooltip-link text-accent" style="margin-top:6px;display:inline-block;background:none;border:none;padding:0;font-size:12px;font-weight:600;text-decoration:underline;cursor:pointer;">View departments moved</button>`
-            : ""
-          }
-        `);
-
-      positionTooltipAtCursor(event);
-
-      tooltip.transition().duration(200).style("opacity", 1);
-    };
-
-    const hideTooltipDelayed = () => {
-      hideTimer = setTimeout(() => {
-        tooltip
-          .transition()
-          .duration(200)
-          .style("opacity", 0)
-          .on("end", () => tooltip.style("pointer-events", "none"));
-      }, 150);
-    };
-
-    tooltip
-      .on("mouseenter", () => {
-        if (hideTimer) {
-          clearTimeout(hideTimer);
-          hideTimer = null;
-        }
-      })
-      .on("mouseleave", hideTooltipDelayed)
-      .on("click", (event) => {
-        event.stopPropagation();
-        if (event.target.closest(".sankey-tooltip-link") && activeLinkData) {
-          onLinkClick?.(activeLinkData);
-        }
-      });
-
     // Links
     svg
       .append("g")
@@ -270,24 +161,22 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .attr("stroke", (d, i) => (isHighlighted(d) || !hasActiveSelection ? `url(#gradient-${i})` : greyColor))
       .attr("stroke-opacity", restingOpacity)
       .attr("stroke-width", (d) => Math.max(1, d.width))
-      .style("cursor", onLinkSingleClick ? "pointer" : "default")
+      .style("cursor", onLinkClick ? "pointer" : "default")
       .on("mouseover", (event, d) => {
         const link = d3.select(event.target).transition().duration(200).attr("stroke-opacity", 0.9);
         if (!isHighlighted(d) && hasActiveSelection) {
           link.attr("stroke", greyColorHover);
         }
-        showTooltip(d, event);
       })
       .on("mouseout", (event, d) => {
         const link = d3.select(event.target).transition().duration(200).attr("stroke-opacity", restingOpacity(d));
         if (!isHighlighted(d) && hasActiveSelection) {
           link.attr("stroke", greyColor);
         }
-        hideTooltipDelayed();
       })
       .on("click", (event, d) => {
         event.stopPropagation();
-        onLinkSingleClick?.(d.source);
+        onLinkClick?.(d);
       });
 
     // Column date labels
@@ -388,8 +277,6 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       });
 
     return () => {
-      if (hideTimer) clearTimeout(hideTimer);
-      tooltip.remove();
     };
   }, [data, width, height, isDarkMode, onNodeClick, onNodeNavigate, onLinkClick, onLinkSingleClick, onClearSelection, selectedLink, selectedNode]);
 

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -41,17 +41,43 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       dateToLayer[normalizeDate(d.date)] = i;
     });
 
-    const { nodes, links } = sankey()
+    const totalLayers = chartDates.length;
+
+    // d3-sankey derives its internal column count from the graph's natural
+    // link depth (longest source-link chain), not from our custom nodeAlign
+    // mapping — any layer nodeAlign returns beyond that natural depth gets
+    // silently clamped into the last real column. If no single link-chain in
+    // the data spans every selected date, columns collapse into each other.
+    // Fix: pad the depth calc with an invisible zero-value node chain, one
+    // per date column, forcing d3-sankey to allocate the full column count.
+    const phantomNodes = Array.from({ length: totalLayers }, (_, i) => ({
+      id: `__phantom_${i}`,
+      __phantom: true,
+      __phantomLayer: i,
+    }));
+    const phantomLinks = phantomNodes.slice(1).map((target, i) => ({
+      source: phantomNodes[i],
+      target,
+      value: 0,
+      __phantom: true,
+    }));
+
+    const { nodes: layoutNodes, links: layoutLinks } = sankey()
       .nodeWidth(20)
       .nodePadding(15)
-      .nodeAlign((node) => dateToLayer[normalizeDate(node.time)] ?? 0)
+      .nodeAlign((node) =>
+        node.__phantom ? node.__phantomLayer : dateToLayer[normalizeDate(node.time)] ?? 0
+      )
       .extent([
         [1, topMargin],
         [width - 1, height - bottomMargin],
       ])({
-        nodes: data.nodes.map((d) => Object.assign({}, d)),
-        links: data.links.map((d) => Object.assign({}, d)),
+        nodes: [...data.nodes.map((d) => Object.assign({}, d)), ...phantomNodes],
+        links: [...data.links.map((d) => Object.assign({}, d)), ...phantomLinks],
       });
+
+    const nodes = layoutNodes.filter((n) => !n.__phantom);
+    const links = layoutLinks.filter((l) => !l.__phantom);
 
     // Responsive label truncation
     // Determine how much horizontal space is available for labels on each side.
@@ -70,8 +96,6 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
         layerBounds[l].x1 = Math.max(layerBounds[l].x1, n.x1);
       }
     });
-
-    const totalLayers = chartDates.length;
 
     function labelCharLimit(node) {
       const layer = node.layer;
@@ -102,27 +126,26 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
     // Color scale
     const color = d3.scaleOrdinal(d3.schemeCategory10);
 
-    // Identifies a link by its source/target node ids — links are rebuilt
-    // fresh on every render, so we can't compare object references.
-    const linkKey = (d) => `${d.source.id ?? d.source}->${d.target.id ?? d.target}`;
-    const selectedKey = selectedLink
-      ? `${selectedLink.source?.id ?? selectedLink.source}->${selectedLink.target?.id ?? selectedLink.target}`
-      : null;
+    const nodeKey = (n) => `${n?.id ?? n}::${normalizeDate(n?.time)}`;
+    const selectedNodeKey = selectedNode ? nodeKey(selectedNode) : null;
+
+    const linkKey = (d) => `${nodeKey(d.source)}->${nodeKey(d.target)}`;
+    const selectedKey = selectedLink ? linkKey(selectedLink) : null;
     const isSelectedLink = (d) => !!selectedKey && linkKey(d) === selectedKey;
     const isLinkedToSelectedNode = (d) =>
-      !!selectedNode && (d.source.id === selectedNode.id || d.target.id === selectedNode.id);
+      !!selectedNodeKey && (nodeKey(d.source) === selectedNodeKey || nodeKey(d.target) === selectedNodeKey);
     const isHighlighted = (d) => isSelectedLink(d) || isLinkedToSelectedNode(d);
-    const hasActiveSelection = !!selectedKey || !!selectedNode;
+    const hasActiveSelection = !!selectedKey || !!selectedNodeKey;
 
-    const relevantNodeIds = new Set();
-    if (selectedNode) relevantNodeIds.add(selectedNode.id);
+    const relevantNodeKeys = new Set();
+    if (selectedNodeKey) relevantNodeKeys.add(selectedNodeKey);
     links.forEach((d) => {
       if (isHighlighted(d)) {
-        relevantNodeIds.add(d.source.id);
-        relevantNodeIds.add(d.target.id);
+        relevantNodeKeys.add(nodeKey(d.source));
+        relevantNodeKeys.add(nodeKey(d.target));
       }
     });
-    const isRelevantNode = (d) => !hasActiveSelection || relevantNodeIds.has(d.id);
+    const isRelevantNode = (d) => !hasActiveSelection || relevantNodeKeys.has(nodeKey(d));
 
     const greyColor = isDarkMode ? "#4b5563" : "#64748b";
     const greyColorHover = isDarkMode ? "#6b7280" : "#c0c7d1";
@@ -343,8 +366,8 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .attr("width", (d) => d.x1 - d.x0)
       .attr("fill", (d) => color(d.id))
       .attr("fill-opacity", (d) => (isRelevantNode(d) ? 1 : 0.25))
-      .attr("stroke", (d) => (selectedNode?.id === d.id ? (isDarkMode ? "#fff" : "#1f2933") : "none"))
-      .attr("stroke-width", (d) => (selectedNode?.id === d.id ? 0 : 0))
+      .attr("stroke", (d) => (nodeKey(d) === selectedNodeKey ? (isDarkMode ? "#fff" : "#1f2933") : "none"))
+      .attr("stroke-width", (d) => (nodeKey(d) === selectedNodeKey ? 0 : 0))
       .style("cursor", onNodeClick ? "pointer" : "default")
       .on("click", handleNodeClick)
       .append("title")

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -27,7 +27,9 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], selectedDates = []
 
     const handleLinkClick = useCallback((link) => {
         setSelectedNode(null);
-        setSelectedLink(link);
+        setSelectedLink((prev) => 
+            (prev?.source?.id === link.source?.id && prev?.target?.id === link.target?.id) ? null : link
+        );
     }, []);
     const handleNodeClick = useCallback((node) => {
         setSelectedLink(null);

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -174,7 +174,6 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                             onNodeClick={handleNodeClick}
                             onNodeNavigate={onMinistryNodeClick}
                             onLinkClick={handleLinkClick}
-                            onLinkSingleClick={handleNodeClick}
                             onClearSelection={handleClearSelection}
                             selectedLink={selectedLink}
                             selectedNode={selectedNode}

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -1,22 +1,12 @@
-import { useState, useCallback, useMemo, useEffect } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { Calendar, BarChart2, Building2, ArrowRight } from "lucide-react";
-import DateRangePicker from "../components/DateRangePicker";
 import CabinetFlowPanel from "../components/CabinetFlowPanel";
 import RightSidePanel from "../../../components/RightSidePanel";
 import { useEntityNames } from "../../../hooks/useEntityNames";
 
-const formatEndDateForPicker = (finalEnd, hasPresidentEndTime) => {
-    if (!hasPresidentEndTime) {
-        return finalEnd.toISOString().split("T")[0];
-    }
-    const d = new Date(finalEnd);
-    d.setDate(d.getDate() - 1);
-    return d.toISOString().split("T")[0];
-};
-
-const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClick }) => {
+const CabinetFlow = ({ presidentId, dateRange = [null, null], selectedDates = [], onMinistryNodeClick }) => {
     const location = useLocation();
     const { gazetteData } = useSelector((state) => state.gazettes);
     const gazetteDates = Array.isArray(gazetteData) ? gazetteData.map(item => item.date) : [];
@@ -24,56 +14,6 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
         (s) => s.presidency.presidentRelationDict
     );
     const presidentRelation = presidentRelationDict[presidentId];
-
-    const [rangeStart, rangeEnd] = dateRange;
-
-    const { startDate, endDate } = useMemo(() => {
-        if (!presidentRelation?.startTime) {
-            return { startDate: null, endDate: null };
-        }
-
-        const presStart = new Date(presidentRelation.startTime.split("T")[0]);
-        const hasPresidentEndTime = !!presidentRelation.endTime;
-        const presEnd = hasPresidentEndTime
-            ? new Date(presidentRelation.endTime.split("T")[0])
-            : new Date();
-
-        const finalStart = rangeStart
-            ? new Date(Math.max(presStart.getTime(), rangeStart.getTime()))
-            : presStart;
-        const finalEnd = rangeEnd
-            ? new Date(Math.min(presEnd.getTime(), rangeEnd.getTime()))
-            : presEnd;
-
-        const start = finalStart.toISOString().split("T")[0];
-        let end = formatEndDateForPicker(finalEnd, hasPresidentEndTime);
-
-        if (start > end) {
-            end = start;
-        }
-
-        return { startDate: start, endDate: end };
-    }, [presidentRelation, rangeStart, rangeEnd]);
-
-    const [selectedDates, setSelectedDates] = useState([]);
-
-    useEffect(() => {
-        if (!startDate) {
-            setSelectedDates([]);
-            return;
-        }
-        const init = [startDate];
-        if (endDate && endDate !== startDate) {
-            init.push(endDate);
-        }
-        setSelectedDates(init);
-    }, [startDate, endDate, presidentId]);
-
-    const handleToggleDate = useCallback((date) => {
-        setSelectedDates((prev) =>
-            prev.includes(date) ? prev.filter((d) => d !== date) : [...prev, date]
-        );
-    }, []);
 
     const sortedDates = [...selectedDates].sort();
 
@@ -141,26 +81,10 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                                     >
                                         <Calendar size={11} />
                                         {d}
-                                        <button
-                                            onClick={() => handleToggleDate(d)}
-                                            className="ml-1 hover:text-red-400 transition-colors hover:cursor-pointer"
-                                        >
-                                            ×
-                                        </button>
                                     </span>
                                 ))}
                             </div>
                         )}
-                        <div className="flex justify-end gap-2">
-                            <DateRangePicker
-                                startDate={startDate}
-                                endDate={endDate}
-                                selectedDates={selectedDates}
-                                onToggle={handleToggleDate}
-                                maxDates={3}
-                                gazetteDates={gazetteDates}
-                            />
-                        </div>
                     </div>
                 </div>
             </div>

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -1,22 +1,13 @@
 import { useState, useCallback, useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
-import { useSelector } from "react-redux";
 import { Calendar, BarChart2, Building2, ArrowRight } from "lucide-react";
 import CabinetFlowPanel from "../components/CabinetFlowPanel";
 import RightSidePanel from "../../../components/RightSidePanel";
 import { useEntityNames } from "../../../hooks/useEntityNames";
 
-const CabinetFlow = ({ presidentId, dateRange = [null, null], selectedDates = [], onMinistryNodeClick }) => {
+const CabinetFlow = ({ presidentId, selectedDates = [], onMinistryNodeClick }) => {
     const location = useLocation();
-    const { gazetteData } = useSelector((state) => state.gazettes);
-    const gazetteDates = Array.isArray(gazetteData) ? gazetteData.map(item => item.date) : [];
-    const presidentRelationDict = useSelector(
-        (s) => s.presidency.presidentRelationDict
-    );
-    const presidentRelation = presidentRelationDict[presidentId];
-
     const sortedDates = [...selectedDates].sort();
-
     const [selectedLink, setSelectedLink] = useState(null);
     const [selectedNode, setSelectedNode] = useState(null);
 
@@ -61,9 +52,9 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], selectedDates = []
         <div className="bg-background min-h-screen rounded-lg border border-border p-8">
             {/* ── Header ── */}
             <div className="w-full mb-6">
-                <div className="flex items-center justify-between gap-2">
-                    <div>
-                        <div className="space-y-1 text-xs md:text-sm text-gray-500 dark:text-gray-400 max-w-2xl">
+                <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
+                    <div className="w-full md:w-auto lg:min-w-[40rem]">
+                        <div className="space-y-1 text-xs md:text-sm text-gray-500 dark:text-gray-400 w-full">
                             <p>This chart visualizes how ministries and departments evolved during the president's tenure.</p>
                             <ul className="list-disc list-inside space-y-0.5 pl-1">
                                 <li>Each column represents a date when one or more changes may have occurred.</li>

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -131,7 +131,7 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                             <ul className="list-disc list-inside space-y-0.5 pl-1">
                                 <li>Each column represents a date when one or more changes may have occurred.</li>
                                 <li>Hover over a flow to view details about the departments involved.</li>
-                                <li>You can select any number of dates to compare.</li>
+                                <li>You can select up to 10 dates to compare.</li>
                             </ul>
                         </div>
                     </div>
@@ -186,7 +186,7 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                         <div className="mt-4 mb-4 ms-0 me-0 rounded-xl border border-dashed border-border bg-gray-50 dark:bg-gray-900/50 flex flex-col items-center justify-center gap-2 py-20 px-6 text-center">
                             <BarChart2 size={28} className="text-gray-300 dark:text-gray-600" />
                             <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                                {selectedDates.length === 1 ? "Select at least 2 dates to compare" : "Select dates to compare"}
+                                {selectedDates.length === 1 ? "Select at least 2 dates to compare" : "Select up to 10 dates to compare"}
                             </p>
                             <p className="text-xs text-gray-400 dark:text-gray-500 max-w-md">
                                 {selectedDates.length === 1

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -56,7 +56,7 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], selectedDates = []
     );
 
     return (
-        <div className="px-4 py-6 md:px-8 md:py-10 lg:px-12 xl:px-10 2xl:px-20 bg-background min-h-screen ms-4 me-4 mb-4 rounded-lg border border-border">
+        <div className="bg-background min-h-screen rounded-lg border border-border p-8">
             {/* ── Header ── */}
             <div className="w-full mb-6">
                 <div className="flex items-center justify-between gap-2">
@@ -104,7 +104,7 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], selectedDates = []
                             selectedNode={selectedNode}
                         />
                     ) : (
-                        <div className="mt-4 mb-4 ms-0 me-0 rounded-xl border border-dashed border-border bg-gray-50 dark:bg-gray-900/50 flex flex-col items-center justify-center gap-2 py-20 px-6 text-center">
+                        <div className="mt-4 mb-4 ms-0 me-0 rounded-lg border border-dashed border-border bg-gray-50 dark:bg-gray-900/50 flex flex-col items-center justify-center gap-2 py-20 px-6 text-center">
                             <BarChart2 size={28} className="text-gray-300 dark:text-gray-600" />
                             <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
                                 {selectedDates.length === 1 ? "Select at least 2 dates to compare" : "Select up to 3 dates to compare"}

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -18,9 +18,7 @@ const CabinetFlow = ({ presidentId, selectedDates = [], onMinistryNodeClick }) =
 
     const handleLinkClick = useCallback((link) => {
         setSelectedNode(null);
-        setSelectedLink((prev) =>
-            (prev?.source?.id === link.source?.id && prev?.target?.id === link.target?.id) ? null : link
-        );
+        setSelectedLink(link);
     }, []);
     const handleNodeClick = useCallback((node) => {
         setSelectedLink(null);

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -126,7 +126,7 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                             <ul className="list-disc list-inside space-y-0.5 pl-1">
                                 <li>Each column represents a date when one or more changes may have occurred.</li>
                                 <li>Hover over a flow to view details about the departments involved.</li>
-                                <li>You can select up to 3 dates to compare.</li>
+                                <li>You can select any number of dates to compare.</li>
                             </ul>
                         </div>
                     </div>
@@ -157,7 +157,6 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                                 endDate={endDate}
                                 selectedDates={selectedDates}
                                 onToggle={handleToggleDate}
-                                maxDates={3}
                                 gazetteDates={gazetteDates}
                             />
                         </div>
@@ -182,7 +181,7 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                         <div className="mt-4 mb-4 ms-0 me-0 rounded-xl border border-dashed border-border bg-gray-50 dark:bg-gray-900/50 flex flex-col items-center justify-center gap-2 py-20 px-6 text-center">
                             <BarChart2 size={28} className="text-gray-300 dark:text-gray-600" />
                             <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                                {selectedDates.length === 1 ? "Select at least 2 dates to compare" : "Select up to 3 dates to compare"}
+                                {selectedDates.length === 1 ? "Select at least 2 dates to compare" : "Select dates to compare"}
                             </p>
                             <p className="text-xs text-gray-400 dark:text-gray-500 max-w-md">
                                 {selectedDates.length === 1

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -27,7 +27,7 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], selectedDates = []
 
     const handleLinkClick = useCallback((link) => {
         setSelectedNode(null);
-        setSelectedLink((prev) => 
+        setSelectedLink((prev) =>
             (prev?.source?.id === link.source?.id && prev?.target?.id === link.target?.id) ? null : link
         );
     }, []);
@@ -68,7 +68,7 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], selectedDates = []
                             <ul className="list-disc list-inside space-y-0.5 pl-1">
                                 <li>Each column represents a date when one or more changes may have occurred.</li>
                                 <li>Hover over a flow to view details about the departments involved.</li>
-                                <li>You can select up to 3 dates to compare.</li>
+                                <li>You can select up to 10 dates to compare.</li>
                             </ul>
                         </div>
                     </div>
@@ -109,7 +109,7 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], selectedDates = []
                         <div className="mt-4 mb-4 ms-0 me-0 rounded-lg border border-dashed border-border bg-gray-50 dark:bg-gray-900/50 flex flex-col items-center justify-center gap-2 py-20 px-6 text-center">
                             <BarChart2 size={28} className="text-gray-300 dark:text-gray-600" />
                             <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                                {selectedDates.length === 1 ? "Select at least 2 dates to compare" : "Select up to 3 dates to compare"}
+                                {selectedDates.length === 1 ? "Select at least 2 dates to compare" : "Select up to 10 dates to compare"}
                             </p>
                             <p className="text-xs text-gray-400 dark:text-gray-500 max-w-md">
                                 {selectedDates.length === 1

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -91,7 +91,12 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
     }, []);
     const handleNodeClick = useCallback((node) => {
         setSelectedLink(null);
-        setSelectedNode((prev) => (prev?.id === node.id ? null : node));
+        // Same id can appear as a separate node at multiple dates, so the
+        // toggle-off check needs id + date, not just id.
+        const normalizeDate = (d) => (typeof d === "string" ? d.split("T")[0] : d);
+        setSelectedNode((prev) =>
+            prev?.id === node.id && normalizeDate(prev?.time) === normalizeDate(node.time) ? null : node
+        );
     }, []);
     const handleClosePanel = useCallback(() => {
         setSelectedLink(null);

--- a/src/utils/navigationUtils.js
+++ b/src/utils/navigationUtils.js
@@ -61,7 +61,7 @@ export const handleResultNavigation = async (result, {
             params.set("filterByName", result.name);
 
             if (onComplete) onComplete();
-            navigate(`/organization?${params.toString()}`, {
+            navigate(`/executive-branch?${params.toString()}`, {
                 state: { searchResultName: result.name },
             });
             break;


### PR DESCRIPTION
## Summary
- Fixed link clicks so clicking an already-selected link now closes the right panel (`onClearSelection`) instead of just re-firing `onLinkClick`.
- Fixed a Sankey layout bug where selecting more than 2-3 dates could collapse middle/later date columns into one another — d3-sankey was deriving its column count from the graph's natural link depth rather than the actual number of selected dates, silently clamping nodes into the wrong column.
- Fixed an over-highlighting bug where clicking a node or link would incorrectly highlight unrelated links/nodes that shared the same id across different dates (the same department/ministry can appear as a separate node at each date it exists in). Selection matching is now keyed on id + date instead of id alone.
- Removed, then reintroduced, the date-picker selection cap — now fixed at a maximum of 10 selectable dates.

## Note 
The GI service ran on commit [5432299dec062fa5374f3e398609bda43aaf36fa] fix: Enabling data retrieval for more than 2 given dates in cabinet flow API since the apis for number of days was changed

## Test plan
- [x] Select 4+ dates spanning a period where not every department changes on every date; confirm all columns render distinctly (no collapsing).
- [x] Click a middle node; confirm only its direct incoming/outgoing links highlight.
- [ ] Click a link between two dates where the same department repeats across several consecutive dates; confirm only that specific link highlights.
- [x] Click an already-selected link; confirm the right panel closes.