### PR TITLE
fix: correct Sankey chart column layout, selection highlighting, and date picker limit

### DIFF
--- a/src/pages/cabinetFlowPage/components/CabinetFlowPanel.jsx
+++ b/src/pages/cabinetFlowPage/components/CabinetFlowPanel.jsx
@@ -4,7 +4,7 @@ import SankeyChart from "./SankeyChart";
 import { BarChart2 } from "lucide-react";
 import { useThemeContext } from "../../../context/themeContext";
 
-const CabinetFlowPanel = ({ presidentId, dates, onNodeClick, onNodeNavigate, onLinkClick, onLinkSingleClick, onClearSelection, selectedLink, selectedNode }) => {
+const CabinetFlowPanel = ({ presidentId, dates, onNodeClick, onNodeNavigate, onLinkClick, onClearSelection, selectedLink, selectedNode }) => {
     const { isDark } = useThemeContext();
     const containerRef = useRef(null);
     const [containerWidth, setContainerWidth] = useState(0);
@@ -78,7 +78,6 @@ const CabinetFlowPanel = ({ presidentId, dates, onNodeClick, onNodeNavigate, onL
                     onNodeClick={onNodeClick}
                     onNodeNavigate={onNodeNavigate}
                     onLinkClick={onLinkClick}
-                    onLinkSingleClick={onLinkSingleClick}
                     onClearSelection={onClearSelection}
                     selectedLink={selectedLink}
                     selectedNode={selectedNode}

--- a/src/pages/cabinetFlowPage/components/DateRangePicker.jsx
+++ b/src/pages/cabinetFlowPage/components/DateRangePicker.jsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { Calendar, ChevronLeft } from "lucide-react";
 
-const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, maxDates = 3, gazetteDates }) => {
+const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, gazetteDates }) => {
     const [isOpen, setIsOpen] = useState(false);
 
     const datePickerRef = useRef(null);
@@ -41,7 +41,7 @@ const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, maxDates
 
     const isInRange = (d) => allDatesSet.has(d);
     const isSelected = (d) => selectedDates.includes(d);
-    const isDisabled = (d) => !isSelected(d) && selectedDates.length >= maxDates;
+    const isDisabled = () => false;
     const isEdge = (d) => d === startDate || d === endDate;
 
     const daysInMonth = new Date(viewMonth.year, viewMonth.month + 1, 0).getDate();
@@ -78,7 +78,7 @@ const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, maxDates
 
     const triggerLabel =
         selectedDates.length === 0
-            ? "Select up to 3 dates"
+            ? "Select dates"
             : selectedDates.length === 1
                 ? selectedDates[0]
                 : `${selectedDates.length} dates selected`;
@@ -94,7 +94,7 @@ const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, maxDates
                 <span>{triggerLabel}</span>
                 {selectedDates.length > 0 && (
                     <span className="ml-1 px-1.5 py-0.5 rounded-full bg-accent/10 text-accent text-xs font-semibold">
-                        {selectedDates.length}/{maxDates}
+                        {selectedDates.length}
                     </span>
                 )}
                 <ChevronLeft
@@ -181,7 +181,7 @@ const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, maxDates
                     {/* Footer */}
                     <div className="mt-3 pt-3 border-t border-border flex items-center justify-between">
                         <p className="text-xs text-gray-400">
-                            <span className="font-semibold text-accent">{selectedDates.length}</span>/{maxDates} selected
+                            <span className="font-semibold text-accent">{selectedDates.length}</span> selected
                         </p>
                         <div className="flex gap-2">
                             {selectedDates.length > 0 && (

--- a/src/pages/cabinetFlowPage/components/DateRangePicker.jsx
+++ b/src/pages/cabinetFlowPage/components/DateRangePicker.jsx
@@ -1,6 +1,8 @@
 import { useState, useRef, useEffect } from "react";
 import { Calendar, ChevronLeft } from "lucide-react";
 
+const MAX_DATES = 10;
+
 const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, gazetteDates }) => {
     const [isOpen, setIsOpen] = useState(false);
 
@@ -41,7 +43,7 @@ const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, gazetteD
 
     const isInRange = (d) => allDatesSet.has(d);
     const isSelected = (d) => selectedDates.includes(d);
-    const isDisabled = () => false;
+    const isDisabled = (d) => !isSelected(d) && selectedDates.length >= MAX_DATES;
     const isEdge = (d) => d === startDate || d === endDate;
 
     const daysInMonth = new Date(viewMonth.year, viewMonth.month + 1, 0).getDate();
@@ -78,7 +80,7 @@ const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, gazetteD
 
     const triggerLabel =
         selectedDates.length === 0
-            ? "Select dates"
+            ? `Select up to ${MAX_DATES} dates`
             : selectedDates.length === 1
                 ? selectedDates[0]
                 : `${selectedDates.length} dates selected`;
@@ -94,7 +96,7 @@ const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, gazetteD
                 <span>{triggerLabel}</span>
                 {selectedDates.length > 0 && (
                     <span className="ml-1 px-1.5 py-0.5 rounded-full bg-accent/10 text-accent text-xs font-semibold">
-                        {selectedDates.length}
+                        {selectedDates.length}/{MAX_DATES}
                     </span>
                 )}
                 <ChevronLeft
@@ -181,7 +183,7 @@ const DateRangePicker = ({ startDate, endDate, selectedDates, onToggle, gazetteD
                     {/* Footer */}
                     <div className="mt-3 pt-3 border-t border-border flex items-center justify-between">
                         <p className="text-xs text-gray-400">
-                            <span className="font-semibold text-accent">{selectedDates.length}</span> selected
+                            <span className="font-semibold text-accent">{selectedDates.length}</span>/{MAX_DATES} selected
                         </p>
                         <div className="flex gap-2">
                             {selectedDates.length > 0 && (

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -2,7 +2,7 @@ import * as d3 from "d3";
 import { sankey, sankeyLinkHorizontal } from "d3-sankey";
 import { useEffect, useRef } from "react";
 
-export default function SankeyChart({ data, width, height, isDarkMode, onNodeClick, onNodeNavigate, onLinkClick, onLinkSingleClick, onClearSelection, selectedLink, selectedNode }) {
+export default function SankeyChart({ data, width, height, isDarkMode, onNodeClick, onNodeNavigate, onLinkClick, onClearSelection, selectedLink, selectedNode }) {
   const containerRef = useRef();
   const svgRef = useRef();
 
@@ -150,7 +150,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .attr("offset", "100%")
       .attr("stop-color", (d) => color(d.target.id));
 
-    // Tooltip — pinned next to the hovered link's nodes, not the cursor
+    // Tooltip — pinned next to the hovered/clicked link's nodes, not the cursor
     const tooltip = container
       .append("div")
       .attr("class", "sankey-tooltip")
@@ -172,10 +172,9 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
 
     // Hovering the link or the tooltip itself keeps it open; leaving both hides it
     let hideTimer = null;
-    let activeLinkData = null;
 
-    // Pins the tooltip right where the cursor entered the link, once — it
-    // does NOT track mousemove afterwards, so it stays put under the cursor
+    // Pins the tooltip right where the cursor entered/clicked the link, once —
+    // it does NOT track mousemove afterwards, so it stays put under the cursor
     // instead of requiring the user to travel to find it.
     const positionTooltipAtCursor = (event) => {
       const containerRect = containerRef.current.getBoundingClientRect();
@@ -214,7 +213,6 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
         clearTimeout(hideTimer);
         hideTimer = null;
       }
-      activeLinkData = d;
       tooltip
         .style("pointer-events", "auto")
         .html(`
@@ -222,10 +220,6 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
             <strong>${d.source.name}</strong> → <strong>${d.target.name}</strong><br/>
             ${d.value} department${d.value > 1 ? "s" : ""} moved
           </div>
-          ${onLinkClick
-            ? `<button type="button" class="sankey-tooltip-link text-accent" style="margin-top:6px;display:inline-block;background:none;border:none;padding:0;font-size:12px;font-weight:600;text-decoration:underline;cursor:pointer;">View departments moved</button>`
-            : ""
-          }
         `);
 
       positionTooltipAtCursor(event);
@@ -250,13 +244,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
           hideTimer = null;
         }
       })
-      .on("mouseleave", hideTooltipDelayed)
-      .on("click", (event) => {
-        event.stopPropagation();
-        if (event.target.closest(".sankey-tooltip-link") && activeLinkData) {
-          onLinkClick?.(activeLinkData);
-        }
-      });
+      .on("mouseleave", hideTooltipDelayed);
 
     // Links
     svg
@@ -270,7 +258,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .attr("stroke", (d, i) => (isHighlighted(d) || !hasActiveSelection ? `url(#gradient-${i})` : greyColor))
       .attr("stroke-opacity", restingOpacity)
       .attr("stroke-width", (d) => Math.max(1, d.width))
-      .style("cursor", onLinkSingleClick ? "pointer" : "default")
+      .style("cursor", onLinkClick ? "pointer" : "default")
       .on("mouseover", (event, d) => {
         const link = d3.select(event.target).transition().duration(200).attr("stroke-opacity", 0.9);
         if (!isHighlighted(d) && hasActiveSelection) {
@@ -287,7 +275,8 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       })
       .on("click", (event, d) => {
         event.stopPropagation();
-        onLinkSingleClick?.(d.source);
+        showTooltip(d, event);
+        onLinkClick?.(d);
       });
 
     // Column date labels
@@ -391,7 +380,7 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       if (hideTimer) clearTimeout(hideTimer);
       tooltip.remove();
     };
-  }, [data, width, height, isDarkMode, onNodeClick, onNodeNavigate, onLinkClick, onLinkSingleClick, onClearSelection, selectedLink, selectedNode]);
+  }, [data, width, height, isDarkMode, onNodeClick, onNodeNavigate, onLinkClick, onClearSelection, selectedLink, selectedNode]);
 
   return (
     <div ref={containerRef} style={{ position: "relative", overflow: "hidden" }}>

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -173,9 +173,8 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
     // Hovering the link or the tooltip itself keeps it open; leaving both hides it
     let hideTimer = null;
 
-    // Pins the tooltip right where the cursor entered/clicked the link, once —
-    // it does NOT track mousemove afterwards, so it stays put under the cursor
-    // instead of requiring the user to travel to find it.
+    // Repositions the tooltip relative to the current cursor position so it
+    // tracks the mouse while hovering a link.
     const positionTooltipAtCursor = (event) => {
       const containerRect = containerRef.current.getBoundingClientRect();
       const tooltipNode = tooltip.node();
@@ -265,6 +264,9 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
           link.attr("stroke", greyColorHover);
         }
         showTooltip(d, event);
+      })
+      .on("mousemove", (event) => {
+        positionTooltipAtCursor(event);
       })
       .on("mouseout", (event, d) => {
         const link = d3.select(event.target).transition().duration(200).attr("stroke-opacity", restingOpacity(d));

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -81,18 +81,19 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
         // 2 column layout: split the single gap 50/50 between both columns
         const gap = layerBounds[1].x0 - layerBounds[0].x1;
         availablePx = gap / 2 - LABEL_PADDING;
+      } else if (layer === 0) {
+        // first column: label renders to the right, full gap to the next column is free
+        const nextX0 = layerBounds[1]?.x0 ?? width;
+        availablePx = nextX0 - layerBounds[0].x1 - LABEL_PADDING;
+      } else if (layer === totalLayers - 1) {
+        // last column: label renders to the left, full gap to the previous column is free
+        const prevX1 = layerBounds[layer - 1]?.x1 ?? 0;
+        availablePx = layerBounds[layer].x0 - prevX1 - LABEL_PADDING;
       } else {
-        // 3 column layout:
-        // for col 1 -> full gaap to col 2
-        // for col 2 to col 3 -> split the gap by 50/50 and use for both col 2 and col 3
-        if (layer === 0) {
-          const nextX0 = layerBounds[1]?.x0 ?? width;
-          availablePx = nextX0 - layerBounds[0].x1 - LABEL_PADDING;
-        } else {
-          const prevX1 = layerBounds[layer - 1]?.x1 ?? 0;
-          const gap = layerBounds[layer].x0 - prevX1;
-          availablePx = gap / 2 - LABEL_PADDING;
-        }
+        // middle columns: split the gap to the previous column 50/50
+        const prevX1 = layerBounds[layer - 1]?.x1 ?? 0;
+        const gap = layerBounds[layer].x0 - prevX1;
+        availablePx = gap / 2 - LABEL_PADDING;
       }
 
       return Math.max(8, Math.floor(availablePx / CHAR_WIDTH_PX));

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -277,8 +277,12 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       })
       .on("click", (event, d) => {
         event.stopPropagation();
-        showTooltip(d, event);
-        onLinkClick?.(d);
+        if (isSelectedLink(d)) {
+          onClearSelection?.();
+        } else {
+          showTooltip(d, event);
+          onLinkClick?.(d);
+        }
       });
 
     // Column date labels

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -19,11 +19,8 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
     const parseDate = d3.utcParse("%Y-%m-%d");
     const formatDate = d3.utcFormat("%b %d %Y");
 
-    const container = d3.select(containerRef.current);
-
-    // Clear any existing SVG content & tooltips
+    // Clear any existing SVG content
     d3.select(svgRef.current).selectAll("*").remove();
-    container.selectAll(".sankey-tooltip").remove();
 
     const svg = d3
       .select(svgRef.current)
@@ -150,101 +147,6 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .attr("offset", "100%")
       .attr("stop-color", (d) => color(d.target.id));
 
-    // Tooltip — pinned next to the hovered/clicked link's nodes, not the cursor
-    const tooltip = container
-      .append("div")
-      .attr("class", "sankey-tooltip")
-      .style("position", "absolute")
-      .style("background", "rgba(0, 0, 0, 0.85)")
-      .style("color", "#fff")
-      .style("padding", "8px 10px")
-      .style("border-radius", "4px")
-      .style("font-size", "12px")
-      .style("pointer-events", "none")
-      .style("opacity", 0)
-      // FIX: constrain width so it never exceeds the container
-      .style("max-width", "min(260px, 80%)")
-      .style("word-wrap", "break-word")
-      .style("white-space", "normal")
-      .style("line-height", "1.5")
-      // Prevent the tooltip itself from causing the container to grow
-      .style("box-sizing", "border-box");
-
-    // Hovering the link or the tooltip itself keeps it open; leaving both hides it
-    let hideTimer = null;
-
-    // Repositions the tooltip relative to the current cursor position so it
-    // tracks the mouse while hovering a link.
-    const positionTooltipAtCursor = (event) => {
-      const containerRect = containerRef.current.getBoundingClientRect();
-      const tooltipNode = tooltip.node();
-      const tooltipWidth = tooltipNode.offsetWidth;
-      const tooltipHeight = tooltipNode.offsetHeight;
-      const MARGIN = 8;
-
-      // The chart container can be taller/wider than the actual browser
-      // viewport (e.g. a tall chart with many nodes), so clamp against
-      // both the container's own box AND the visible viewport — in
-      // container-local coordinates — and use whichever is tighter.
-      const minX = Math.max(0, -containerRect.left) + MARGIN;
-      const maxX = Math.min(containerRect.width, window.innerWidth - containerRect.left) - tooltipWidth - MARGIN;
-      const minY = Math.max(0, -containerRect.top) + MARGIN;
-      const maxY = Math.min(containerRect.height, window.innerHeight - containerRect.top) - tooltipHeight - MARGIN;
-
-      let x = event.clientX - containerRect.left + 12;
-      let y = event.clientY - containerRect.top + 12;
-
-      if (x > maxX) {
-        x = event.clientX - containerRect.left - tooltipWidth - 12;
-      }
-      x = Math.min(Math.max(x, minX), maxX);
-
-      if (y > maxY) {
-        y = event.clientY - containerRect.top - tooltipHeight - 12;
-      }
-      y = Math.min(Math.max(y, minY), maxY);
-
-      tooltip.style("left", `${x}px`).style("top", `${y}px`);
-    };
-
-    const showTooltip = (d, event) => {
-      if (hideTimer) {
-        clearTimeout(hideTimer);
-        hideTimer = null;
-      }
-      tooltip
-        .style("pointer-events", "auto")
-        .html(`
-          <div>
-            <strong>${d.source.name}</strong> → <strong>${d.target.name}</strong><br/>
-            ${d.value} department${d.value > 1 ? "s" : ""} moved
-          </div>
-        `);
-
-      positionTooltipAtCursor(event);
-
-      tooltip.transition().duration(200).style("opacity", 1);
-    };
-
-    const hideTooltipDelayed = () => {
-      hideTimer = setTimeout(() => {
-        tooltip
-          .transition()
-          .duration(200)
-          .style("opacity", 0)
-          .on("end", () => tooltip.style("pointer-events", "none"));
-      }, 150);
-    };
-
-    tooltip
-      .on("mouseenter", () => {
-        if (hideTimer) {
-          clearTimeout(hideTimer);
-          hideTimer = null;
-        }
-      })
-      .on("mouseleave", hideTooltipDelayed);
-
     // Links
     svg
       .append("g")
@@ -263,22 +165,20 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
         if (!isHighlighted(d) && hasActiveSelection) {
           link.attr("stroke", greyColorHover);
         }
-        showTooltip(d, event);
-      })
-      .on("mousemove", (event) => {
-        positionTooltipAtCursor(event);
       })
       .on("mouseout", (event, d) => {
         const link = d3.select(event.target).transition().duration(200).attr("stroke-opacity", restingOpacity(d));
         if (!isHighlighted(d) && hasActiveSelection) {
           link.attr("stroke", greyColor);
         }
-        hideTooltipDelayed();
       })
       .on("click", (event, d) => {
         event.stopPropagation();
-        showTooltip(d, event);
-        onLinkClick?.(d);
+        if (isSelectedLink(d)) {
+          onClearSelection?.();
+        } else {
+          onLinkClick?.(d);
+        }
       });
 
     // Column date labels
@@ -377,11 +277,6 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .on("mouseleave", function () {
         d3.select(this).style("text-decoration", null);
       });
-
-    return () => {
-      if (hideTimer) clearTimeout(hideTimer);
-      tooltip.remove();
-    };
   }, [data, width, height, isDarkMode, onNodeClick, onNodeNavigate, onLinkClick, onClearSelection, selectedLink, selectedNode]);
 
   return (

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -19,8 +19,11 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
     const parseDate = d3.utcParse("%Y-%m-%d");
     const formatDate = d3.utcFormat("%b %d %Y");
 
-    // Clear any existing SVG content
+    const container = d3.select(containerRef.current);
+
+    // Clear any existing SVG content & tooltips
     d3.select(svgRef.current).selectAll("*").remove();
+    container.selectAll(".sankey-tooltip").remove();
 
     const svg = d3
       .select(svgRef.current)
@@ -147,6 +150,101 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .attr("offset", "100%")
       .attr("stop-color", (d) => color(d.target.id));
 
+    // Tooltip — pinned next to the hovered/clicked link's nodes, not the cursor
+    const tooltip = container
+      .append("div")
+      .attr("class", "sankey-tooltip")
+      .style("position", "absolute")
+      .style("background", "rgba(0, 0, 0, 0.85)")
+      .style("color", "#fff")
+      .style("padding", "8px 10px")
+      .style("border-radius", "4px")
+      .style("font-size", "12px")
+      .style("pointer-events", "none")
+      .style("opacity", 0)
+      // FIX: constrain width so it never exceeds the container
+      .style("max-width", "min(260px, 80%)")
+      .style("word-wrap", "break-word")
+      .style("white-space", "normal")
+      .style("line-height", "1.5")
+      // Prevent the tooltip itself from causing the container to grow
+      .style("box-sizing", "border-box");
+
+    // Hovering the link or the tooltip itself keeps it open; leaving both hides it
+    let hideTimer = null;
+
+    // Repositions the tooltip relative to the current cursor position so it
+    // tracks the mouse while hovering a link.
+    const positionTooltipAtCursor = (event) => {
+      const containerRect = containerRef.current.getBoundingClientRect();
+      const tooltipNode = tooltip.node();
+      const tooltipWidth = tooltipNode.offsetWidth;
+      const tooltipHeight = tooltipNode.offsetHeight;
+      const MARGIN = 8;
+
+      // The chart container can be taller/wider than the actual browser
+      // viewport (e.g. a tall chart with many nodes), so clamp against
+      // both the container's own box AND the visible viewport — in
+      // container-local coordinates — and use whichever is tighter.
+      const minX = Math.max(0, -containerRect.left) + MARGIN;
+      const maxX = Math.min(containerRect.width, window.innerWidth - containerRect.left) - tooltipWidth - MARGIN;
+      const minY = Math.max(0, -containerRect.top) + MARGIN;
+      const maxY = Math.min(containerRect.height, window.innerHeight - containerRect.top) - tooltipHeight - MARGIN;
+
+      let x = event.clientX - containerRect.left + 12;
+      let y = event.clientY - containerRect.top + 12;
+
+      if (x > maxX) {
+        x = event.clientX - containerRect.left - tooltipWidth - 12;
+      }
+      x = Math.min(Math.max(x, minX), maxX);
+
+      if (y > maxY) {
+        y = event.clientY - containerRect.top - tooltipHeight - 12;
+      }
+      y = Math.min(Math.max(y, minY), maxY);
+
+      tooltip.style("left", `${x}px`).style("top", `${y}px`);
+    };
+
+    const showTooltip = (d, event) => {
+      if (hideTimer) {
+        clearTimeout(hideTimer);
+        hideTimer = null;
+      }
+      tooltip
+        .style("pointer-events", "auto")
+        .html(`
+          <div>
+            <strong>${d.source.name}</strong> → <strong>${d.target.name}</strong><br/>
+            ${d.value} department${d.value > 1 ? "s" : ""} moved
+          </div>
+        `);
+
+      positionTooltipAtCursor(event);
+
+      tooltip.transition().duration(200).style("opacity", 1);
+    };
+
+    const hideTooltipDelayed = () => {
+      hideTimer = setTimeout(() => {
+        tooltip
+          .transition()
+          .duration(200)
+          .style("opacity", 0)
+          .on("end", () => tooltip.style("pointer-events", "none"));
+      }, 150);
+    };
+
+    tooltip
+      .on("mouseenter", () => {
+        if (hideTimer) {
+          clearTimeout(hideTimer);
+          hideTimer = null;
+        }
+      })
+      .on("mouseleave", hideTooltipDelayed);
+
     // Links
     svg
       .append("g")
@@ -165,20 +263,22 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
         if (!isHighlighted(d) && hasActiveSelection) {
           link.attr("stroke", greyColorHover);
         }
+        showTooltip(d, event);
+      })
+      .on("mousemove", (event) => {
+        positionTooltipAtCursor(event);
       })
       .on("mouseout", (event, d) => {
         const link = d3.select(event.target).transition().duration(200).attr("stroke-opacity", restingOpacity(d));
         if (!isHighlighted(d) && hasActiveSelection) {
           link.attr("stroke", greyColor);
         }
+        hideTooltipDelayed();
       })
       .on("click", (event, d) => {
         event.stopPropagation();
-        if (isSelectedLink(d)) {
-          onClearSelection?.();
-        } else {
-          onLinkClick?.(d);
-        }
+        showTooltip(d, event);
+        onLinkClick?.(d);
       });
 
     // Column date labels
@@ -277,6 +377,11 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .on("mouseleave", function () {
         d3.select(this).style("text-decoration", null);
       });
+
+    return () => {
+      if (hideTimer) clearTimeout(hideTimer);
+      tooltip.remove();
+    };
   }, [data, width, height, isDarkMode, onNodeClick, onNodeNavigate, onLinkClick, onClearSelection, selectedLink, selectedNode]);
 
   return (

--- a/src/pages/cabinetFlowPage/components/SankeyChart.jsx
+++ b/src/pages/cabinetFlowPage/components/SankeyChart.jsx
@@ -41,17 +41,43 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       dateToLayer[normalizeDate(d.date)] = i;
     });
 
-    const { nodes, links } = sankey()
+    const totalLayers = chartDates.length;
+
+    // d3-sankey derives its internal column count from the graph's natural
+    // link depth (longest source-link chain), not from our custom nodeAlign
+    // mapping — any layer nodeAlign returns beyond that natural depth gets
+    // silently clamped into the last real column. If no single link-chain in
+    // the data spans every selected date, columns collapse into each other.
+    // Fix: pad the depth calc with an invisible zero-value node chain, one
+    // per date column, forcing d3-sankey to allocate the full column count.
+    const phantomNodes = Array.from({ length: totalLayers }, (_, i) => ({
+      id: `__phantom_${i}`,
+      __phantom: true,
+      __phantomLayer: i,
+    }));
+    const phantomLinks = phantomNodes.slice(1).map((target, i) => ({
+      source: phantomNodes[i],
+      target,
+      value: 0,
+      __phantom: true,
+    }));
+
+    const { nodes: layoutNodes, links: layoutLinks } = sankey()
       .nodeWidth(20)
       .nodePadding(15)
-      .nodeAlign((node) => dateToLayer[normalizeDate(node.time)] ?? 0)
+      .nodeAlign((node) =>
+        node.__phantom ? node.__phantomLayer : dateToLayer[normalizeDate(node.time)] ?? 0
+      )
       .extent([
         [1, topMargin],
         [width - 1, height - bottomMargin],
       ])({
-        nodes: data.nodes.map((d) => Object.assign({}, d)),
-        links: data.links.map((d) => Object.assign({}, d)),
+        nodes: [...data.nodes.map((d) => Object.assign({}, d)), ...phantomNodes],
+        links: [...data.links.map((d) => Object.assign({}, d)), ...phantomLinks],
       });
+
+    const nodes = layoutNodes.filter((n) => !n.__phantom);
+    const links = layoutLinks.filter((l) => !l.__phantom);
 
     // Responsive label truncation
     // Determine how much horizontal space is available for labels on each side.
@@ -70,8 +96,6 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
         layerBounds[l].x1 = Math.max(layerBounds[l].x1, n.x1);
       }
     });
-
-    const totalLayers = chartDates.length;
 
     function labelCharLimit(node) {
       const layer = node.layer;
@@ -102,27 +126,26 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
     // Color scale
     const color = d3.scaleOrdinal(d3.schemeCategory10);
 
-    // Identifies a link by its source/target node ids — links are rebuilt
-    // fresh on every render, so we can't compare object references.
-    const linkKey = (d) => `${d.source.id ?? d.source}->${d.target.id ?? d.target}`;
-    const selectedKey = selectedLink
-      ? `${selectedLink.source?.id ?? selectedLink.source}->${selectedLink.target?.id ?? selectedLink.target}`
-      : null;
+    const nodeKey = (n) => `${n?.id ?? n}::${normalizeDate(n?.time)}`;
+    const selectedNodeKey = selectedNode ? nodeKey(selectedNode) : null;
+
+    const linkKey = (d) => `${nodeKey(d.source)}->${nodeKey(d.target)}`;
+    const selectedKey = selectedLink ? linkKey(selectedLink) : null;
     const isSelectedLink = (d) => !!selectedKey && linkKey(d) === selectedKey;
     const isLinkedToSelectedNode = (d) =>
-      !!selectedNode && (d.source.id === selectedNode.id || d.target.id === selectedNode.id);
+      !!selectedNodeKey && (nodeKey(d.source) === selectedNodeKey || nodeKey(d.target) === selectedNodeKey);
     const isHighlighted = (d) => isSelectedLink(d) || isLinkedToSelectedNode(d);
-    const hasActiveSelection = !!selectedKey || !!selectedNode;
+    const hasActiveSelection = !!selectedKey || !!selectedNodeKey;
 
-    const relevantNodeIds = new Set();
-    if (selectedNode) relevantNodeIds.add(selectedNode.id);
+    const relevantNodeKeys = new Set();
+    if (selectedNodeKey) relevantNodeKeys.add(selectedNodeKey);
     links.forEach((d) => {
       if (isHighlighted(d)) {
-        relevantNodeIds.add(d.source.id);
-        relevantNodeIds.add(d.target.id);
+        relevantNodeKeys.add(nodeKey(d.source));
+        relevantNodeKeys.add(nodeKey(d.target));
       }
     });
-    const isRelevantNode = (d) => !hasActiveSelection || relevantNodeIds.has(d.id);
+    const isRelevantNode = (d) => !hasActiveSelection || relevantNodeKeys.has(nodeKey(d));
 
     const greyColor = isDarkMode ? "#4b5563" : "#64748b";
     const greyColorHover = isDarkMode ? "#6b7280" : "#c0c7d1";
@@ -343,8 +366,8 @@ export default function SankeyChart({ data, width, height, isDarkMode, onNodeCli
       .attr("width", (d) => d.x1 - d.x0)
       .attr("fill", (d) => color(d.id))
       .attr("fill-opacity", (d) => (isRelevantNode(d) ? 1 : 0.25))
-      .attr("stroke", (d) => (selectedNode?.id === d.id ? (isDarkMode ? "#fff" : "#1f2933") : "none"))
-      .attr("stroke-width", (d) => (selectedNode?.id === d.id ? 0 : 0))
+      .attr("stroke", (d) => (nodeKey(d) === selectedNodeKey ? (isDarkMode ? "#fff" : "#1f2933") : "none"))
+      .attr("stroke-width", (d) => (nodeKey(d) === selectedNodeKey ? 0 : 0))
       .style("cursor", onNodeClick ? "pointer" : "default")
       .on("click", handleNodeClick)
       .append("title")

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -174,7 +174,6 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                             onNodeClick={handleNodeClick}
                             onNodeNavigate={onMinistryNodeClick}
                             onLinkClick={handleLinkClick}
-                            onLinkSingleClick={handleNodeClick}
                             onClearSelection={handleClearSelection}
                             selectedLink={selectedLink}
                             selectedNode={selectedNode}

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -131,7 +131,7 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                             <ul className="list-disc list-inside space-y-0.5 pl-1">
                                 <li>Each column represents a date when one or more changes may have occurred.</li>
                                 <li>Hover over a flow to view details about the departments involved.</li>
-                                <li>You can select any number of dates to compare.</li>
+                                <li>You can select up to 10 dates to compare.</li>
                             </ul>
                         </div>
                     </div>
@@ -186,7 +186,7 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                         <div className="mt-4 mb-4 ms-0 me-0 rounded-xl border border-dashed border-border bg-gray-50 dark:bg-gray-900/50 flex flex-col items-center justify-center gap-2 py-20 px-6 text-center">
                             <BarChart2 size={28} className="text-gray-300 dark:text-gray-600" />
                             <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                                {selectedDates.length === 1 ? "Select at least 2 dates to compare" : "Select dates to compare"}
+                                {selectedDates.length === 1 ? "Select at least 2 dates to compare" : "Select up to 10 dates to compare"}
                             </p>
                             <p className="text-xs text-gray-400 dark:text-gray-500 max-w-md">
                                 {selectedDates.length === 1

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -126,7 +126,7 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                             <ul className="list-disc list-inside space-y-0.5 pl-1">
                                 <li>Each column represents a date when one or more changes may have occurred.</li>
                                 <li>Hover over a flow to view details about the departments involved.</li>
-                                <li>You can select up to 3 dates to compare.</li>
+                                <li>You can select any number of dates to compare.</li>
                             </ul>
                         </div>
                     </div>
@@ -157,7 +157,6 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                                 endDate={endDate}
                                 selectedDates={selectedDates}
                                 onToggle={handleToggleDate}
-                                maxDates={3}
                                 gazetteDates={gazetteDates}
                             />
                         </div>
@@ -182,7 +181,7 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
                         <div className="mt-4 mb-4 ms-0 me-0 rounded-xl border border-dashed border-border bg-gray-50 dark:bg-gray-900/50 flex flex-col items-center justify-center gap-2 py-20 px-6 text-center">
                             <BarChart2 size={28} className="text-gray-300 dark:text-gray-600" />
                             <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                                {selectedDates.length === 1 ? "Select at least 2 dates to compare" : "Select up to 3 dates to compare"}
+                                {selectedDates.length === 1 ? "Select at least 2 dates to compare" : "Select dates to compare"}
                             </p>
                             <p className="text-xs text-gray-400 dark:text-gray-500 max-w-md">
                                 {selectedDates.length === 1

--- a/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
+++ b/src/pages/cabinetFlowPage/screens/CabinetFlow.jsx
@@ -91,7 +91,12 @@ const CabinetFlow = ({ presidentId, dateRange = [null, null], onMinistryNodeClic
     }, []);
     const handleNodeClick = useCallback((node) => {
         setSelectedLink(null);
-        setSelectedNode((prev) => (prev?.id === node.id ? null : node));
+        // Same id can appear as a separate node at multiple dates, so the
+        // toggle-off check needs id + date, not just id.
+        const normalizeDate = (d) => (typeof d === "string" ? d.split("T")[0] : d);
+        setSelectedNode((prev) =>
+            prev?.id === node.id && normalizeDate(prev?.time) === normalizeDate(node.time) ? null : node
+        );
     }, []);
     const handleClosePanel = useCallback(() => {
         setSelectedLink(null);


### PR DESCRIPTION
# Fixes and Improvements

## Summary

- Fixed link click behavior:
  - Clicking an already-selected link now closes the right-side panel by triggering `onClearSelection` instead of re-triggering `onLinkClick`.

- Fixed a Sankey layout issue:
  - Resolved a bug where selecting more than 2–3 dates could cause middle and later date columns to collapse into one another.
  - The issue occurred because `d3-sankey` derived the number of columns from the graph's natural link depth rather than the actual number of selected dates, causing nodes to be silently clamped into incorrect columns.
  - The layout now correctly respects the full set of selected dates.

- Fixed incorrect highlighting:
  - Resolved an issue where selecting a node or link would incorrectly highlight unrelated nodes and links sharing the same department/ministry ID across different dates.
  - Selection matching is now based on the combination of **`id + date`** instead of `id` alone, ensuring only the intended node/link is highlighted.

- Updated date picker behavior:
  - Removed and then reintroduced the selection limit.
  - The date picker now enforces a maximum of **10 selectable dates**.

## Note

The GI service was run using commit:

`5432299dec062fa5374f3e398609bda43aaf36fa`

**Commit message:**

> fix: Enabling data retrieval for more than 2 given dates in cabinet flow API since the APIs for number of days was changed

---