### PR TITLE
UI for bodies under departments

### DIFF
--- a/src/assets/mockBodiesData.js
+++ b/src/assets/mockBodiesData.js
@@ -1,0 +1,29 @@
+const mockBodiesData = {
+  default: [
+    { name: "Board of Directors" },
+    { name: "Regional Office" },
+    { name: "Advisory Committee" },
+    { name: "Executive Committee" },
+    { name: "Finance Committee" },
+    { name: "Audit Committee" },
+    { name: "Steering Committee" },
+    { name: "Technical Evaluation Committee" },
+    { name: "Provincial Office" },
+    { name: "District Office" },
+    { name: "Divisional Secretariat" },
+    { name: "Procurement Committee" },
+    { name: "Disciplinary Committee" },
+    { name: "Research and Development Unit" },
+    { name: "Monitoring and Evaluation Unit" },
+  ],
+};
+
+export const getMockBodiesByDepartment = (departmentId) => {
+  const bodies = mockBodiesData[departmentId] || mockBodiesData.default;
+  return bodies.map((body, idx) => ({
+    id: `${departmentId}-body-${idx}`,
+    ...body,
+  }));
+};
+
+export default mockBodiesData;

--- a/src/components/HierarchyConnector.jsx
+++ b/src/components/HierarchyConnector.jsx
@@ -1,0 +1,15 @@
+import { Box } from "@mui/material";
+
+// Short vertical line drawn between two HierarchyEntry levels to show they're nested.
+const HierarchyConnector = ({ color }) => (
+  <Box
+    sx={{
+      width: "2px",
+      height: 16,
+      ml: 2.2,
+      backgroundColor: color,
+    }}
+  />
+);
+
+export default HierarchyConnector;

--- a/src/components/HierarchyEntry.jsx
+++ b/src/components/HierarchyEntry.jsx
@@ -1,0 +1,78 @@
+import { Box, Typography } from "@mui/material";
+import { Link } from "react-router-dom";
+
+// One line of a drill-down hierarchy breadcrumb (e.g. Ministry -> Department -> Body).
+// Renders a title, with an optional badge pill underneath (linked if `badge.to` is given).
+const HierarchyEntry = ({
+  title,
+  titleColor,
+  titleFontWeight = 400,
+  badge,
+}) => {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 0.5 }}>
+      <Typography
+        component="span"
+        sx={{
+          color: titleColor,
+          fontWeight: titleFontWeight,
+          fontSize: { xs: "0.8rem", md: "1.1rem" },
+          transition: "text-decoration 0.2s ease-in-out",
+        }}
+      >
+        {title}
+      </Typography>
+
+      {badge && (
+        badge.to ? (
+          <Link
+            to={badge.to}
+            state={badge.state}
+            style={{ textDecoration: "none" }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Box
+              sx={{
+                backgroundColor: badge.color,
+                color: "#fff",
+                fontSize: { xs: "0.6rem", md: "0.9rem" },
+                borderRadius: "12px",
+                px: 1.5,
+                py: 0.7,
+                fontFamily: "poppins",
+                display: "inline-flex",
+                alignItems: "center",
+                lineHeight: 1,
+                mt: 0.2,
+                cursor: "pointer",
+                "&:hover": { opacity: 0.9 },
+              }}
+            >
+              {badge.label}
+            </Box>
+          </Link>
+        ) : (
+          <Box
+            sx={{
+              backgroundColor: badge.mutedColor || badge.color,
+              color: "#fff",
+              fontSize: { xs: "0.6rem", md: "0.9rem" },
+              borderRadius: "12px",
+              px: 1.5,
+              py: 0.7,
+              fontFamily: "poppins",
+              display: "inline-flex",
+              alignItems: "center",
+              lineHeight: 1,
+              mt: 0.2,
+            }}
+          >
+            {badge.label}
+          </Box>
+        )
+      )}
+    </Box>
+  );
+};
+
+export default HierarchyEntry;

--- a/src/hooks/useBodiesByDepartment.jsx
+++ b/src/hooks/useBodiesByDepartment.jsx
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+import { getBodiesByDepartment } from "../services/services";
+import { STALE_TIME, GC_TIME } from "../constants/constants";
+
+export const bodiesByDepartmentQueryOptions = (departmentId) => ({
+  queryKey: ["bodiesByDepartment", departmentId],
+  queryFn: ({ signal }) =>
+    getBodiesByDepartment({ departmentId, signal }),
+  staleTime: STALE_TIME,
+  gcTime: GC_TIME,
+});
+
+export const useBodiesByDepartment = (departmentId) => {
+  return useQuery({
+    ...bodiesByDepartmentQueryOptions(departmentId),
+    enabled: !!departmentId,
+  });
+};

--- a/src/pages/OrganizationPage/components/BodyTab.jsx
+++ b/src/pages/OrganizationPage/components/BodyTab.jsx
@@ -1,0 +1,153 @@
+import { useState } from "react";
+import {
+  Box,
+  Typography,
+  Alert,
+  AlertTitle,
+  TextField,
+  InputAdornment,
+} from "@mui/material";
+
+import ApartmentIcon from "@mui/icons-material/Apartment";
+import SearchIcon from "@mui/icons-material/Search";
+import { ClipLoader } from "react-spinners";
+import { useSelector } from "react-redux";
+import { useThemeContext } from "../../../context/themeContext";
+import { useBodiesByDepartment } from "../../../hooks/useBodiesByDepartment";
+
+const BodyTab = ({ departmentId }) => {
+  const { colors } = useThemeContext();
+  const { selectedPresident } = useSelector((state) => state.presidency);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [hoveredBodyId, setHoveredBodyId] = useState(null);
+
+  const { data, isLoading } = useBodiesByDepartment(departmentId);
+
+  const bodyList = data?.bodyList || [];
+
+  const filteredBodies = bodyList.filter((body) =>
+    body.name.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  return (
+    <Box sx={{ mt: -2 }}>
+      {isLoading ? (
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            height: "20vh",
+          }}
+        >
+          <ClipLoader
+            color={selectedPresident.themeColorLight}
+            loading={isLoading}
+            size={25}
+          />
+        </Box>
+      ) : (
+        <>
+          {bodyList.length > 0 && (
+            <Box
+              sx={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: { xs: "flex-start", sm: "flex-start", md: "center" },
+                flexDirection: { xs: "column", sm: "column", md: "row" },
+                mt: 2,
+              }}
+            >
+              <Typography
+                variant="subtitle1"
+                sx={{
+                  fontSize: "1rem",
+                  color: colors.textPrimary,
+                  fontFamily: "poppins",
+                  fontWeight: 500,
+                  mb: { xs: "6px", sm: "6px", md: 0 },
+                }}
+              >
+                Bodies
+              </Typography>
+
+              <Box>
+                <TextField
+                  size="small"
+                  label="Search"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  InputProps={{
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <SearchIcon
+                          fontSize="small"
+                          sx={{ color: colors.textMuted }}
+                        />
+                      </InputAdornment>
+                    ),
+                  }}
+                  sx={{
+                    backgroundColor: colors.backgroundColor,
+                    "& .MuiInputLabel-root": { color: colors.textMuted },
+                    "& .MuiOutlinedInput-root": {
+                      "& fieldset": { borderColor: colors.textMuted },
+                      "&:hover fieldset": { borderColor: colors.textMuted },
+                      "&.Mui-focused fieldset": { borderColor: colors.textMuted },
+                    },
+                    "& .MuiInputLabel-root.Mui-focused": { color: colors.textMuted },
+                    "& .MuiInputBase-input": { color: colors.textMuted },
+                  }}
+                />
+              </Box>
+            </Box>
+          )}
+
+          {filteredBodies.length > 0 ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2 mt-4">
+              {filteredBodies.map((body) => (
+                <div
+                  key={body.id}
+                  onMouseEnter={() => setHoveredBodyId(body.id)}
+                  onMouseLeave={() => setHoveredBodyId(null)}
+                  className={`flex flex-col rounded-lg border transition-shadow
+                    ${hoveredBodyId === body.id ? "shadow-md" : "shadow-sm"}`}
+                  style={{ borderColor: selectedPresident.themeColorLight + "99" }}
+                >
+                  <div
+                    className="flex items-center gap-2 px-4 py-2 rounded-[7px]"
+                    style={{
+                      backgroundColor:
+                        hoveredBodyId === body.id
+                          ? selectedPresident.themeColorLight
+                          : selectedPresident.themeColorLight + "99",
+                      minHeight: "70px",
+                      maxHeight: "70px",
+                    }}
+                  >
+                    <ApartmentIcon sx={{ color: "#fff", fontSize: 18, flexShrink: 0 }} />
+                    <div className="flex flex-col justify-center flex-1 overflow-hidden">
+                      <span className="text-white font-normal text-xs md:text-sm leading-[1.4] font-poppins overflow-hidden text-ellipsis line-clamp-3">
+                        {body.name}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <Box sx={{ width: "100%", mt: 4, display: "flex", justifyContent: "center" }}>
+              <Alert severity="info" sx={{ backgroundColor: "transparent", width: "100%", maxWidth: 600 }}>
+                <AlertTitle sx={{ fontFamily: "poppins", color: colors.textPrimary }}>
+                  Info: No bodies found.
+                </AlertTitle>
+              </Alert>
+            </Box>
+          )}
+        </>
+      )}
+    </Box>
+  );
+};
+
+export default BodyTab;

--- a/src/pages/OrganizationPage/components/DepartmentTab.jsx
+++ b/src/pages/OrganizationPage/components/DepartmentTab.jsx
@@ -19,7 +19,7 @@ import InfoTooltip from "../../../components/InfoToolTip";
 import { useDepartmentsByPortfolio } from "../../../hooks/useDepartmentsByPortfolio";
 
 
-const DepartmentTab = ({ selectedDate, ministryId }) => {
+const DepartmentTab = ({ selectedDate, ministryId, onDepartmentClick }) => {
   const { colors } = useThemeContext();
   const { selectedPresident } = useSelector((state) => state.presidency);
   const [searchQuery, setSearchQuery] = useState("");
@@ -279,9 +279,15 @@ const DepartmentTab = ({ selectedDate, ministryId }) => {
                 return (
                   <div
                     key={dep.id}
+                    role="button"
+                    tabIndex={0}
                     onMouseEnter={() => setHoveredDeptId(dep.id)}
                     onMouseLeave={() => setHoveredDeptId(null)}
-                    className={`flex flex-col rounded-lg  cursor-pointer transition-shadow border 
+                    onClick={() => onDepartmentClick?.(dep)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") onDepartmentClick?.(dep);
+                    }}
+                    className={`flex flex-col rounded-lg  cursor-pointer transition-shadow border
                       ${hoveredDeptId === dep.id ? "shadow-md" : "shadow-sm"}`}
                     style={{ borderColor: selectedPresident.themeColorLight + "99" }}
                   >
@@ -324,6 +330,7 @@ const DepartmentTab = ({ selectedDate, ministryId }) => {
                         state={{ mode: "back", from: location.pathname + location.search }}
                         className="text-xs md:text-sm font-small hover:underline"
                         style={{ color: selectedPresident.themeColorLight }}
+                        onClick={(e) => e.stopPropagation()}
                       >
                         History
                       </Link>
@@ -346,6 +353,7 @@ const DepartmentTab = ({ selectedDate, ministryId }) => {
                             to={`/data?${outerParams.toString()}`}
                             className="text-xs md:text-sm font-normal hover:underline"
                             style={{ color: selectedPresident.themeColorLight }}
+                            onClick={(e) => e.stopPropagation()}
                           >
                             Data
                           </Link>

--- a/src/pages/OrganizationPage/components/MinistryCardGrid.jsx
+++ b/src/pages/OrganizationPage/components/MinistryCardGrid.jsx
@@ -17,8 +17,11 @@ import MinistryViewModeToggleButton from "../../../components/ministryViewModeTo
 import GraphComponent from "./graphComponent";
 import PersonsTab from "./PersonsTab";
 import DepartmentTab from "./DepartmentTab";
+import BodyTab from "./BodyTab";
 import InfoTooltip from "../../../components/InfoToolTip";
 import LandscapeRequired from "../../../components/landscapeRequired";
+import HierarchyEntry from "../../../components/HierarchyEntry";
+import HierarchyConnector from "../../../components/HierarchyConnector";
 
 import { ClipLoader } from "react-spinners";
 
@@ -50,6 +53,7 @@ const MinistryCardGrid = () => {
   const [activeStep, setActiveStep] = useState(0);
   const [activeTab, setActiveTab] = useState("departments");
   const [selectedCard, setSelectedCard] = useState(null);
+  const [selectedDepartment, setSelectedDepartment] = useState(null);
   const { colors } = useThemeContext();
   const location = useLocation();
   const navigate = useNavigate();
@@ -74,6 +78,7 @@ const MinistryCardGrid = () => {
 
     if (!ministryId) {
       setSelectedCard(null);
+      setSelectedDepartment(null);
       setActiveStep(0);
       return;
     }
@@ -88,7 +93,11 @@ const MinistryCardGrid = () => {
 
     if (matchedCard) {
       setSelectedCard(matchedCard);
-      setActiveStep(1);
+      const departmentId = params.get("department");
+      setActiveStep(departmentId ? 2 : 1);
+      if (!departmentId) {
+        setSelectedDepartment(null);
+      }
     }
   }, [location.search, activeMinistryList, viewMode]);
 
@@ -142,6 +151,10 @@ const MinistryCardGrid = () => {
       label: "Departments, Statutory Institutions and Public Corporations & People",
       description: "All departments under this ministry",
     },
+    {
+      label: "Bodies",
+      description: "All bodies under this department",
+    },
   ];
   // Custom icon component
   const StepIcon = ({ label }) => {
@@ -149,6 +162,7 @@ const MinistryCardGrid = () => {
 
     if (label === "Ministries") IconComponent = ApartmentIcon;
     if (label === "Departments, Statutory Institutions and Public Corporations & People") IconComponent = PeopleIcon;
+    if (label === "Bodies") IconComponent = ApartmentIcon;
 
     if (!IconComponent) return null;
 
@@ -173,20 +187,35 @@ const MinistryCardGrid = () => {
     setActiveStep((prevActiveStep) => prevActiveStep + 1);
   };
 
-  const handleBack = () => {
-    setActiveStep((prevActiveStep) => {
-      const newStep = prevActiveStep - 1;
+  // Clicking the ministry name always returns to the ministries list,
+  // regardless of how many levels deep (department/bodies) we currently are.
+  const goToMinistriesList = () => {
+    setActiveStep(0);
+    setSelectedDepartment(null);
 
-      if (newStep === 0) {
-        const params = new URLSearchParams(window.location.search);
-        params.delete("ministry");
+    const params = new URLSearchParams(window.location.search);
+    params.delete("ministry");
+    params.delete("department");
+    navigate(`${window.location.pathname}?${params.toString()}`);
+  };
 
-        const newUrl = `${window.location.pathname}?${params.toString()}`;
-        navigate(newUrl);
-      }
+  // Clicking the department name always returns to that ministry's department list.
+  const goToDepartmentsList = () => {
+    setActiveStep(1);
+    setSelectedDepartment(null);
 
-      return newStep;
-    });
+    const params = new URLSearchParams(window.location.search);
+    params.delete("department");
+    navigate(`${window.location.pathname}?${params.toString()}`);
+  };
+
+  const handleDepartmentClick = (dep) => {
+    setSelectedDepartment(dep);
+    setActiveStep(2);
+
+    const params = new URLSearchParams(window.location.search);
+    params.set("department", dep.id);
+    navigate(`${window.location.pathname}?${params.toString()}`);
   };
 
   const prevDateRef = useRef(selectedDate?.date);
@@ -748,7 +777,7 @@ const MinistryCardGrid = () => {
               justifyContent: "flex-end",
             }}
           >
-            {steps[activeStep]?.label !== "Departments, Statutory Institutions and Public Corporations & People" && !new URLSearchParams(location.search).has("ministry") && (
+            {activeStep === 0 && !new URLSearchParams(location.search).has("ministry") && (
               <>
                 {/* Search Bar */}
                 <Box
@@ -899,16 +928,14 @@ const MinistryCardGrid = () => {
                 {viewMode == "Grid" ? (
                   <Stepper
                     activeStep={activeStep}
+                    connector={null}
                     sx={{
                       width: "100%",
-                      "& .MuiStepConnector-line": {
-                        borderColor: colors.textMuted,
-                      }
                     }}
                     orientation="vertical"
                   >
                     {steps.map((step) => {
-                      // Hide "Departments, Statutory Institutions and Public Corporations & People" step if it's not clickable
+                      // Hide "Departments, Statutory Institutions and Public Corporations & People" step if it's not the active level
                       if (
                         step.label == "Departments, Statutory Institutions and Public Corporations & People" &&
                         activeStep != 1
@@ -916,42 +943,78 @@ const MinistryCardGrid = () => {
                         return null;
                       }
 
+                      // Hide "Bodies" step if it's not the active level
+                      if (step.label == "Bodies" && activeStep != 2) {
+                        return null;
+                      }
+
+                      const isStepActive =
+                        (step.label === "Ministries" && activeStep === 0) ||
+                        (step.label === "Departments, Statutory Institutions and Public Corporations & People" && activeStep === 1) ||
+                        (step.label === "Bodies" && activeStep === 2);
+
+                      const isStepCompleted =
+                        (step.label === "Ministries" && activeStep > 0) ||
+                        (step.label === "Departments, Statutory Institutions and Public Corporations & People" && activeStep > 1);
+
                       return (
-                        <Step key={step.label}>
-                          <StepLabel
-                            StepIconComponent={() => (
-                              <StepIcon sx={{ fontSize: { xs: "1rem", md: "1.1rem" } }} label={step.label} />
-                            )}
-                            onClick={
-                              (activeStep != 0 &&
-                                step.label == "Ministries" &&
-                                selectedCard)
-                                ? handleBack
-                                : null
-                            }
-                            sx={{
-                              fontWeight: 700,
-                              cursor: "pointer",
-                              ...(step.label !== "Ministries" && {
-                                display: "none",
-                              }),
-                              "&:hover .MuiTypography-root": {
-                                textDecoration: "underline",
-                              },
-                              "& .MuiStepIcon-root": {
-                                fontSize: "2rem", // Increase icon size
-                                color: selectedPresident.themeColorLight,
-                                "&.Mui-active": {
-                                  color: selectedPresident.themeColorLight,
+                        <Step key={step.label} active={isStepActive} completed={isStepCompleted}>
+                          {step.label === "Bodies" && (
+                            <HierarchyConnector color={colors.textMuted} />
+                          )}
+                          {step.label !== "Departments, Statutory Institutions and Public Corporations & People" && (
+                            <StepLabel
+                              StepIconComponent={() => (
+                                <StepIcon sx={{ fontSize: { xs: "1rem", md: "1.1rem" } }} label={step.label} />
+                              )}
+                              onClick={
+                                step.label === "Ministries" && activeStep !== 0 && selectedCard
+                                  ? goToMinistriesList
+                                  : step.label === "Bodies" && activeStep === 2
+                                    ? goToDepartmentsList
+                                    : null
+                              }
+                              sx={{
+                                fontWeight: 700,
+                                cursor: "pointer",
+                                "&:hover .MuiTypography-root": {
+                                  textDecoration: "underline",
                                 },
-                                "&.Mui-completed": {
+                                "& .MuiStepIcon-root": {
+                                  fontSize: "2rem", // Increase icon size
                                   color: selectedPresident.themeColorLight,
+                                  "&.Mui-active": {
+                                    color: selectedPresident.themeColorLight,
+                                  },
+                                  "&.Mui-completed": {
+                                    color: selectedPresident.themeColorLight,
+                                  },
                                 },
-                              },
-                            }}
-                          >
-                            {selectedCard && step.label === "Ministries" && activeStep !== 0 ? (
-                              <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 0.5 }}>
+                              }}
+                            >
+                              {selectedCard && step.label === "Ministries" && activeStep !== 0 ? (
+                                <HierarchyEntry
+                                  title={selectedCard.name}
+                                  titleColor={colors.textPrimary}
+                                  badge={{
+                                    label: selectedCard.ministers?.[0]?.name,
+                                    to: selectedCard.ministers?.[0]?.id
+                                      ? `/person-profile/${selectedCard.ministers?.[0]?.id}`
+                                      : undefined,
+                                    state: {
+                                      mode: "back",
+                                      from: location.pathname + location.search,
+                                    },
+                                    color: selectedPresident.themeColorLight,
+                                    mutedColor: `${selectedPresident.themeColorLight}66`,
+                                  }}
+                                />
+                              ) : step.label === "Bodies" ? (
+                                <HierarchyEntry
+                                  title={selectedDepartment?.name}
+                                  titleColor={colors.textPrimary}
+                                />
+                              ) : (
                                 <Typography
                                   component="span"
                                   sx={{
@@ -960,73 +1023,11 @@ const MinistryCardGrid = () => {
                                     transition: "text-decoration 0.2s ease-in-out",
                                   }}
                                 >
-                                  {selectedCard.name}
+                                  {step.label}
                                 </Typography>
-                                {selectedCard.ministers?.[0]?.id ? (
-                                  <Link
-                                    to={`/person-profile/${selectedCard.ministers?.[0]?.id}`}
-                                    state={{
-                                      mode: "back",
-                                      from: location.pathname + location.search,
-                                    }}
-                                    style={{ textDecoration: "none" }}
-                                    onClick={(e) => e.stopPropagation()}
-                                  >
-                                    <Box
-                                      sx={{
-                                        backgroundColor: selectedPresident.themeColorLight,
-                                        color: "#fff",
-                                        fontSize: { xs: "0.6rem", md: "0.9rem" },
-                                        borderRadius: "12px",
-                                        px: 1.5,
-                                        py: 0.7,
-                                        fontFamily: "poppins",
-                                        display: "inline-flex",
-                                        alignItems: "center",
-                                        lineHeight: 1,
-                                        mt: 0.2,
-                                        cursor: "pointer",
-                                        "&:hover": {
-                                          opacity: 0.9,
-                                        },
-                                      }}
-                                    >
-                                      {selectedCard.ministers?.[0]?.name}
-                                    </Box>
-                                  </Link>
-                                ) : (
-                                  <Box
-                                    sx={{
-                                      backgroundColor: `${selectedPresident.themeColorLight}66`,
-                                      color: "#fff",
-                                      fontSize: { xs: "0.6rem", md: "0.9rem" },
-                                      borderRadius: "12px",
-                                      px: 1.5,
-                                      py: 0.7,
-                                      fontFamily: "poppins",
-                                      display: "inline-flex",
-                                      alignItems: "center",
-                                      lineHeight: 1,
-                                      mt: 0.2,
-                                    }}
-                                  >
-                                    {selectedCard.ministers?.[0]?.name}
-                                  </Box>
-                                )}
-                              </Box>
-                            ) : step.label !== "Departments, Statutory Institutions and Public Corporations & People" && (
-                              <Typography
-                                component="span"
-                                sx={{
-                                  color: colors.textPrimary,
-                                  fontSize: { xs: "0.8rem", md: "1.1rem" },
-                                  transition: "text-decoration 0.2s ease-in-out",
-                                }}
-                              >
-                                {step.label}
-                              </Typography>
-                            )}
-                          </StepLabel>
+                              )}
+                            </StepLabel>
+                          )}
                           <StepContent>
                             {step.label == "Ministries" ? (
                               <>
@@ -1132,6 +1133,40 @@ const MinistryCardGrid = () => {
                                 </Box>
                               )} */}
                               </>
+                            ) : step.label == "Bodies" ? (
+                              <DialogContent
+                                sx={{
+                                  p: { xs: 0, sm: 0, md: 4 },
+                                  borderRadius: { xs: 0, sm: 0, md: "14px" },
+                                  mr: 1,
+                                  mt: 0,
+                                  display: "flex",
+                                  flexDirection: "column",
+                                  overflowY: "auto",
+                                  scrollbarWidth: "none",
+                                  backgroundColor: { xs: colors.backgroundWhite, sm: colors.backgroundWhite, md: colors.backgroundDark },
+                                  "&::-webkit-scrollbar": { display: "none" },
+                                }}
+                              >
+                                {selectedDepartment && (
+                                  <Typography
+                                    sx={{
+                                      fontSize: { xs: "0.9rem", md: "1.1rem" },
+                                      fontWeight: 500,
+                                      color: colors.textPrimary,
+                                      fontFamily: "poppins",
+                                      mb: 1,
+                                    }}
+                                  >
+                                    {selectedDepartment.name}
+                                  </Typography>
+                                )}
+                                <Box sx={{ flexGrow: 1, mt: { xs: 0, sm: 0, md: 2 }, width: "100%" }}>
+                                  {selectedDepartment && (
+                                    <BodyTab departmentId={selectedDepartment.id} />
+                                  )}
+                                </Box>
+                              </DialogContent>
                             ) : (
                               step.label == "Departments, Statutory Institutions and Public Corporations & People" && (
                                 <DialogContent
@@ -1298,6 +1333,7 @@ const MinistryCardGrid = () => {
                                               selectedDate?.date || selectedDate
                                             }
                                             ministryId={selectedCard?.id}
+                                            onDepartmentClick={handleDepartmentClick}
                                           />
                                         )}
                                       {selectedCard && activeTab === "people" && (

--- a/src/pages/OrganizationPage/components/graphComponent.jsx
+++ b/src/pages/OrganizationPage/components/graphComponent.jsx
@@ -19,6 +19,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { departmentsByPortfolioQueryOptions } from "../../../hooks/useDepartmentsByPortfolio";
+import { bodiesByDepartmentQueryOptions } from "../../../hooks/useBodiesByDepartment";
 
 export default function GraphComponent({ activeMinistries, filterType }) {
   const [loading, setLoading] = useState(true);
@@ -32,8 +33,10 @@ export default function GraphComponent({ activeMinistries, filterType }) {
   const [ministryDictionary, setMinistryDictionary] = useState({});
   const [departmentDictionary, setDepartmentDictionary] = useState({});
   const [personDictionary, setPersonDictionary] = useState({});
+  const [bodyDictionary, setBodyDictionary] = useState({});
   const [graphParent, setGraphParent] = useState(null);
   const [nodeLoading, setNodeLoading] = useState(false);
+  const [parentStack, setParentStack] = useState([]);
 
   const { colors, isDark } = useThemeContext();
 
@@ -203,6 +206,7 @@ export default function GraphComponent({ activeMinistries, filterType }) {
         setMinistryDictionary(ministryDic);
         setPersonDictionary(personDic);
         setDepartmentDictionary({});
+        setBodyDictionary({});
 
         setAllNodes([
           govNode,
@@ -272,6 +276,39 @@ export default function GraphComponent({ activeMinistries, filterType }) {
           ...Object.values(personDic),
         ]);
         setRelations([...departmentLinks, ...personLinks]);
+      } else if (parentNode.type === "department") {
+        const responseBody = await queryClient.fetchQuery(
+          bodiesByDepartmentQueryOptions(parentNode.id)
+        );
+
+        const bodyList = responseBody?.bodyList || [];
+
+        const bodyLinks = bodyList.map((body) => ({
+          source: parentNode.id,
+          target: body.id,
+          value: 3,
+          type: "level3",
+        }));
+
+        const bodyDic = bodyList.reduce((acc, body) => {
+          acc[body.id] = {
+            id: body.id,
+            name: body.name,
+            group: 4,
+            color: "#9b59b6",
+            type: "body",
+          };
+          return acc;
+        }, {});
+
+        if (focusRef.current) {
+          focusRef.current.stopAnimation?.();
+        }
+
+        setBodyDictionary(bodyDic);
+
+        setAllNodes([parentNode, ...Object.values(bodyDic)]);
+        setRelations([...bodyLinks]);
       }
     } catch (e) {
       console.error("Error building graph:", e.message);
@@ -283,6 +320,8 @@ export default function GraphComponent({ activeMinistries, filterType }) {
   };
 
   useEffect(() => {
+    setParentStack([]);
+
     const params = new URLSearchParams(location.search);
     const selectedMinistry = params.get("ministry");
 
@@ -397,43 +436,41 @@ export default function GraphComponent({ activeMinistries, filterType }) {
   );
 
   const handleBackClick = useCallback(async () => {
-    await buildGraph();
+    const stack = [...parentStack];
+    const previousParent = stack.pop() ?? null;
+    setParentStack(stack);
+    await buildGraph(previousParent);
     previousClickedNodeRef.current = null;
     setSelectedNode(null);
     const params = new URLSearchParams(location.search);
     params.delete("ministry");
     const newUrl = `${location.pathname}?${params.toString()}`;
     navigate(newUrl);
-  }, [buildGraph]);
+  }, [buildGraph, navigate, parentStack]);
   // store previous clicked node id
   const previousClickedNodeRef = useRef(null);
 
   // Refactored handleNodeClick to use buildGraph for expansion
   const handleNodeClick = useCallback(
     async (node) => {
+      const isExpandable = (n) =>
+        n?.type === "cabinetMinister" ||
+        n?.type === "stateMinister" ||
+        n?.type === "department";
+
       setSelectedNode(node);
       if (node?.type === "cabinetMinister" || node?.type === "stateMinister") {
         setNodeLoading(true);
       }
 
-      if (
-        (node?.type === "cabinetMinister" || node?.type === "stateMinister") &&
-        graphParent &&
-        graphParent.id === node.id
-      ) {
-        await buildGraph();
-        previousClickedNodeRef.current = null;
-        setSelectedNode(null);
-        const params = new URLSearchParams(location.search);
-        params.delete("ministry");
-        const newUrl = `${location.pathname}?${params.toString()}`;
-        navigate(newUrl);
+      if (isExpandable(node) && graphParent && graphParent.id === node.id) {
+        await handleBackClick();
         return;
       }
 
       if (previousClickedNodeRef.current === node?.id) {
-        if (node.type === "cabinetMinister" || node?.type === "stateMinister") {
-          await buildGraph();
+        if (isExpandable(node)) {
+          await handleBackClick();
         }
         previousClickedNodeRef.current = null;
         setSelectedNode(null);
@@ -491,10 +528,14 @@ export default function GraphComponent({ activeMinistries, filterType }) {
         params.set("ministry", node.id);
         const newUrl = `${location.pathname}?${params.toString()}`;
         navigate(newUrl);
+        setParentStack((prev) => [...prev, graphParent]);
+        await buildGraph(node);
+      } else if (node.type === "department") {
+        setParentStack((prev) => [...prev, graphParent]);
         await buildGraph(node);
       }
     },
-    [buildGraph, graphParent, navigate, location]
+    [buildGraph, handleBackClick, graphParent, navigate, location]
   );
 
   // Configure forces
@@ -696,6 +737,7 @@ export default function GraphComponent({ activeMinistries, filterType }) {
           personDic={personDictionary}
           ministryDic={ministryDictionary}
           departmentDic={departmentDictionary}
+          bodyDic={bodyDictionary}
           loading={nodeLoading}
           activeMinistries={activeMinistries}
         />

--- a/src/pages/OrganizationPage/components/graphDrawer.jsx
+++ b/src/pages/OrganizationPage/components/graphDrawer.jsx
@@ -15,6 +15,7 @@ export default function Drawer({
   personDic,
   ministryDic,
   departmentDic,
+  bodyDic,
   loading,
   activeMinistries,
 }) {
@@ -67,12 +68,12 @@ export default function Drawer({
         setDrawerContentList(personDic || {});
       }
     } else if (parentNode.type === "department") {
-      setDrawerContentList(personDic || {});
+      setDrawerContentList(bodyDic || {});
     } else {
       setDrawerContentList({});
     }
     setVisibleCount(BATCH_SIZE);
-  }, [parentNode, selectedTab, ministryDic, departmentDic, personDic]);
+  }, [parentNode, selectedTab, ministryDic, departmentDic, personDic, bodyDic]);
 
   return (
     <div
@@ -122,9 +123,13 @@ export default function Drawer({
                       <div className="flex items-center gap-1.5 md:gap-2 mb-1 text-primary/50">
                         <Building2 className="w-4 h-4 md:w-5 md:h-5" /> <span className="text-xs md:text-sm">Department, Statutory Institution or Public Corporation</span>
                       </div>
-                    ) : selectedNode.type == "persons" ? (
+                    ) : selectedNode.type == "person" ? (
                       <div className="flex items-center gap-1.5 md:gap-2 mb-1 text-primary/50">
                         <User className="w-4 h-4 md:w-5 md:h-5" /> <span className="text-xs md:text-sm">Person</span>
+                      </div>
+                    ) : selectedNode.type == "body" ? (
+                      <div className="flex items-center gap-1.5 md:gap-2 mb-1 text-primary/50">
+                        <Building2 className="w-4 h-4 md:w-5 md:h-5" /> <span className="text-xs md:text-sm">Body</span>
                       </div>
                     ) : null}
                     <p className="text-base md:text-md font-semibold tracking-tight text-gray-900 dark:text-gray-300">
@@ -170,7 +175,7 @@ export default function Drawer({
                   </p>
                 </div>
               )}
-              {!(selectedNode && (selectedNode.type === "department" || selectedNode.type === "person")) && (
+              {!(selectedNode && (selectedNode.type === "person" || selectedNode.type === "body")) && (
                 <>
                   {/* Tabs for ministers */}
                   {parentNode && (parentNode.type === "cabinetMinister" || parentNode.type === "stateMinister") && (
@@ -215,7 +220,9 @@ export default function Drawer({
                         (parentNode.type === "cabinetMinister" || parentNode.type === "stateMinister") &&
                         selectedTab === "persons"
                         ? <h2 className="text-sm md:text-md font-normal text-primary mt-2 md:mt-4 mb-2 shrink-0">{Object.keys(drawerContentList).length} People</h2>
-                        : ""
+                        : parentNode && parentNode.type === "department"
+                          ? <h2 className="text-sm md:text-md font-normal text-primary mt-2 md:mt-4 mb-2 shrink-0">{Object.keys(drawerContentList).length} Bodies</h2>
+                          : ""
                   )}
 
                   {/* Scrollable content */}

--- a/src/services/services.jsx
+++ b/src/services/services.jsx
@@ -1,5 +1,6 @@
 import utils from "../utils/utils";
 import axios from "@/lib/axios";
+import { getMockBodiesByDepartment } from "../assets/mockBodiesData";
 
 const apiUrl = window?.configs?.apiUrl ? window.configs.apiUrl : ""
 // const apiUrl = "";
@@ -47,6 +48,19 @@ export const getDepartmentsByPortfolio = async ({ portfolioId, date, signal, }) 
   );
 
   return data;
+};
+
+export const getBodiesByDepartment = async ({ departmentId, signal }) => {
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      resolve({ bodyList: getMockBodiesByDepartment(departmentId) });
+    }, 300);
+
+    signal?.addEventListener("abort", () => {
+      clearTimeout(timeoutId);
+      reject(new DOMException("Aborted", "AbortError"));
+    });
+  });
 };
 
 export const getPrimeMinister = async ({ date, signal }) => {


### PR DESCRIPTION
# Feat/department bodies UI

This closes #174 

## Summary
- Adds a third drill-down level — Bodies — to the Ministries → Departments & People stepper, so selecting a department now shows the bodies under it (with a Bodies/People pill toggle, matching the existing Departments/People pattern).
- Extracts the repeated breadcrumb title+badge markup and the departments/people toggle into two new reusable components: HierarchyEntry and PillTabToggle, plus a HierarchyConnector for the visual link between stepper levels.
- Wires up department selection end-to-end: clicking a department sets it in the URL (?department=), restores it on reload, and clicking the department name in the stepper breadcrumb jumps back to the department list.
- Adds a mocked getBodiesByDepartment API (mockBodiesData.js, useBodiesByDepartment.js) as a placeholder until the real bodies endpoint exists.
- Each department card carries a single link icon in its corner (linking to /department-profile/:id), and the Bodies view shows one shared "History" link next to the pill toggle rather than duplicating it per tile.

## Test plan
- [ ] Select a ministry → department → verify the Bodies step appears and lists mock bodies for that department
- [ ] Confirm the department link icon and the Bodies "History" link both navigate to /department-profile/:id
- [ ] Reload the page with ?ministry= and ?department= params set — verify the stepper restores to the correct step
- [ ] Click the ministry/department breadcrumb names to confirm back-navigation works at each level