### PR TITLE
Fix: Showing more than one minister in the ministry grid

### DIFF
--- a/src/pages/OrganizationPage/components/MinistryCard.jsx
+++ b/src/pages/OrganizationPage/components/MinistryCard.jsx
@@ -32,7 +32,6 @@ const MinistryCard = ({ card, onClick }) => {
         borderRadius: "10px",
         position: "relative",
         width: "100%",
-        height: "100%",
       }}
       onMouseOver={() => setMouseHover(card)}
       onMouseOut={() => setMouseHover(null)}
@@ -141,7 +140,7 @@ const MinistryCard = ({ card, onClick }) => {
           </Stack>
 
           {/* Name & Badge Section */}
-          <Stack direction="column" spacing={0.75}>
+          <Stack direction="column" spacing={1}>
             {(() => {
               const hasMultipleMinisters = (card.ministers?.length ?? 0) > 1;
               return (card.ministers ?? []).map((minister, idx) => (

--- a/src/pages/OrganizationPage/components/MinistryCard.jsx
+++ b/src/pages/OrganizationPage/components/MinistryCard.jsx
@@ -32,6 +32,7 @@ const MinistryCard = ({ card, onClick }) => {
         borderRadius: "10px",
         position: "relative",
         width: "100%",
+        height: "100%",
       }}
       onMouseOver={() => setMouseHover(card)}
       onMouseOut={() => setMouseHover(null)}

--- a/src/pages/OrganizationPage/components/MinistryCard.jsx
+++ b/src/pages/OrganizationPage/components/MinistryCard.jsx
@@ -142,7 +142,9 @@ const MinistryCard = ({ card, onClick }) => {
 
           {/* Name & Badge Section */}
           <Stack direction="column" spacing={0.75}>
-            {(card.ministers ?? []).map((minister, idx) => (
+            {(() => {
+              const hasMultipleMinisters = (card.ministers?.length ?? 0) > 1;
+              return (card.ministers ?? []).map((minister, idx) => (
               <Stack key={minister.id ?? `${card.id}-minister-${idx}`} direction="column" spacing={0}>
                 {/* President Label */}
                 {minister.isPresident ? (
@@ -184,6 +186,7 @@ const MinistryCard = ({ card, onClick }) => {
                       } : {},
                     }}
                   >
+                    {hasMultipleMinisters && "• "}
                     {minister.name}
                   </Typography>
 
@@ -205,7 +208,8 @@ const MinistryCard = ({ card, onClick }) => {
                   )}
                 </Stack>
               </Stack>
-            ))}
+              ));
+            })()}
           </Stack>
         </Stack>
       </Stack>

--- a/src/pages/OrganizationPage/components/MinistryCard.jsx
+++ b/src/pages/OrganizationPage/components/MinistryCard.jsx
@@ -140,69 +140,71 @@ const MinistryCard = ({ card, onClick }) => {
           </Stack>
 
           {/* Name & Badge Section */}
-          <Stack direction="column" spacing={0}>
-            {/* President Label */}
-            {card.ministers?.[0]?.isPresident ? (
-              <Box sx={{ display: "flex", alignItems: "flex-end" }}>
-                <Typography
-                  variant="subtitle2"
-                  sx={{
-                    color: colors.white,
-                    fontFamily: "poppins",
-                    py: "2px",
-                    px: "6px",
-                    fontSize: { xs: "0.6rem", md: "10px" },
-                    backgroundColor: selectedPresident?.themeColorLight,
-                    borderRadius: "3px",
-                    mb: "2px",
-                  }}
-                >
-                  President
-                </Typography>
-              </Box>
-            ) : null}
+          <Stack direction="column" spacing={0.75}>
+            {(card.ministers ?? []).map((minister, idx) => (
+              <Stack key={minister.id ?? `${card.id}-minister-${idx}`} direction="column" spacing={0}>
+                {/* President Label */}
+                {minister.isPresident ? (
+                  <Box sx={{ display: "flex", alignItems: "flex-end" }}>
+                    <Typography
+                      variant="subtitle2"
+                      sx={{
+                        color: colors.white,
+                        fontFamily: "poppins",
+                        py: "2px",
+                        px: "6px",
+                        fontSize: { xs: "0.6rem", md: "10px" },
+                        backgroundColor: selectedPresident?.themeColorLight,
+                        borderRadius: "3px",
+                        mb: "2px",
+                      }}
+                    >
+                      President
+                    </Typography>
+                  </Box>
+                ) : null}
 
-            {/* Name + NEW badge */}
-            <Stack direction="row" alignItems="center" spacing={1}>
-              <Typography
-                variant="subtitle2"
-                onClick={(e) =>
-                  handleOpenProfile(e, card.ministers?.[0]?.id)
-                }
-                sx={{
-                  fontWeight: 400,
-                  fontSize: { xs: "0.7rem", md: "13px" },
-                  color: colors.textPrimary,
-                  fontFamily: "poppins",
-                  textDecorationThickness: "1px",
-                  textUnderlineOffset: "3px",
-                  cursor: card.ministers?.[0]?.id ? "pointer" : "default",
-                  "&:hover": card.ministers?.[0]?.id ? {
-                    textDecoration: "underline",
-                    opacity: 0.9,
-                  } : {},
-                }}
-              >
-                {card.ministers?.length === 0 ? "" : card.ministers?.[0]?.name}
-              </Typography>
+                {/* Name + NEW badge */}
+                <Stack direction="row" alignItems="center" spacing={1}>
+                  <Typography
+                    variant="subtitle2"
+                    onClick={(e) => handleOpenProfile(e, minister.id)}
+                    sx={{
+                      fontWeight: 400,
+                      fontSize: { xs: "0.7rem", md: "13px" },
+                      color: colors.textPrimary,
+                      fontFamily: "poppins",
+                      textDecorationThickness: "1px",
+                      textUnderlineOffset: "3px",
+                      cursor: minister.id ? "pointer" : "default",
+                      "&:hover": minister.id ? {
+                        textDecoration: "underline",
+                        opacity: 0.9,
+                      } : {},
+                    }}
+                  >
+                    {minister.name}
+                  </Typography>
 
-              {card.ministers?.[0]?.isNew && showPersonBadge && (
-                <Box
-                  sx={{
-                    border: `1px solid ${colors.green}`,
-                    color: colors.green,
-                    fontSize: "0.65rem",
-                    fontWeight: "semibold",
-                    borderRadius: "4px",
-                    px: 1,
-                    py: "1px",
-                    fontFamily: "poppins",
-                  }}
-                >
-                  NEW
-                </Box>
-              )}
-            </Stack>
+                  {minister.isNew && showPersonBadge && (
+                    <Box
+                      sx={{
+                        border: `1px solid ${colors.green}`,
+                        color: colors.green,
+                        fontSize: "0.65rem",
+                        fontWeight: "semibold",
+                        borderRadius: "4px",
+                        px: 1,
+                        py: "1px",
+                        fontFamily: "poppins",
+                      }}
+                    >
+                      NEW
+                    </Box>
+                  )}
+                </Stack>
+              </Stack>
+            ))}
           </Stack>
         </Stack>
       </Stack>

--- a/src/pages/OrganizationPage/components/MinistryCardGrid.jsx
+++ b/src/pages/OrganizationPage/components/MinistryCardGrid.jsx
@@ -968,7 +968,7 @@ const MinistryCardGrid = () => {
                                   {(selectedCard.ministers ?? []).map((minister, idx) =>
                                     minister.id ? (
                                       <Link
-                                        key={minister.id ?? `${selectedCard.id}-minister-${idx}`}
+                                        key={minister.id}
                                         to={`/person-profile/${minister.id}`}
                                         state={{
                                           mode: "back",

--- a/src/pages/OrganizationPage/components/MinistryCardGrid.jsx
+++ b/src/pages/OrganizationPage/components/MinistryCardGrid.jsx
@@ -964,59 +964,63 @@ const MinistryCardGrid = () => {
                                 >
                                   {selectedCard.name}
                                 </Typography>
-                                {selectedCard.ministers?.[0]?.id ? (
-                                  <Link
-                                    to={`/person-profile/${selectedCard.ministers?.[0]?.id}`}
-                                    state={{
-                                      mode: "back",
-                                      from: location.pathname + location.search,
-                                    }}
-                                    style={{ textDecoration: "none" }}
-                                    onClick={(e) => e.stopPropagation()}
-                                  >
-                                    <Box
-                                      sx={{
-                                        backgroundColor: selectedPresident.themeColorLight,
-                                        color: "#fff",
-                                        fontSize: { xs: "0.6rem", md: "0.9rem" },
-                                        borderRadius: "12px",
-                                        px: 1.5,
-                                        py: 0.7,
-                                        fontFamily: "poppins",
-                                        display: "inline-flex",
-                                        alignItems: "center",
-                                        lineHeight: 1,
-                                        mt: 0.2,
-                                        cursor: "pointer",
-                                        "&:hover": {
-                                          opacity: 0.9,
-                                        },
-                                      }}
-                                    >
-                                      {selectedCard.ministers?.[0]?.name}
-                                    </Box>
-                                  </Link>
-                                ) : (
-                                  selectedCard.ministers?.[0]?.name ? (
-                                    <Box
-                                      sx={{
-                                        backgroundColor: `${selectedPresident.themeColorLight}66`,
-                                        color: "#fff",
-                                        fontSize: { xs: "0.6rem", md: "0.9rem" },
-                                        borderRadius: "12px",
-                                        px: 1.5,
-                                        py: 0.7,
-                                        fontFamily: "poppins",
-                                        display: "inline-flex",
-                                        alignItems: "center",
-                                        lineHeight: 1,
-                                        mt: 0.2,
-                                      }}
-                                    >
-                                      {selectedCard.ministers[0].name}
-                                    </Box>
-                                  ) : null
-                                )}
+                                <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+                                  {(selectedCard.ministers ?? []).map((minister, idx) =>
+                                    minister.id ? (
+                                      <Link
+                                        key={minister.id ?? `${selectedCard.id}-minister-${idx}`}
+                                        to={`/person-profile/${minister.id}`}
+                                        state={{
+                                          mode: "back",
+                                          from: location.pathname + location.search,
+                                        }}
+                                        style={{ textDecoration: "none" }}
+                                        onClick={(e) => e.stopPropagation()}
+                                      >
+                                        <Box
+                                          sx={{
+                                            backgroundColor: selectedPresident.themeColorLight,
+                                            color: "#fff",
+                                            fontSize: { xs: "0.6rem", md: "0.9rem" },
+                                            borderRadius: "12px",
+                                            px: 1.5,
+                                            py: 0.7,
+                                            fontFamily: "poppins",
+                                            display: "inline-flex",
+                                            alignItems: "center",
+                                            lineHeight: 1,
+                                            mt: 0.2,
+                                            cursor: "pointer",
+                                            "&:hover": {
+                                              opacity: 0.9,
+                                            },
+                                          }}
+                                        >
+                                          {minister.name}
+                                        </Box>
+                                      </Link>
+                                    ) : minister.name ? (
+                                      <Box
+                                        key={`${selectedCard.id}-minister-${idx}`}
+                                        sx={{
+                                          backgroundColor: `${selectedPresident.themeColorLight}66`,
+                                          color: "#fff",
+                                          fontSize: { xs: "0.6rem", md: "0.9rem" },
+                                          borderRadius: "12px",
+                                          px: 1.5,
+                                          py: 0.7,
+                                          fontFamily: "poppins",
+                                          display: "inline-flex",
+                                          alignItems: "center",
+                                          lineHeight: 1,
+                                          mt: 0.2,
+                                        }}
+                                      >
+                                        {minister.name}
+                                      </Box>
+                                    ) : null
+                                  )}
+                                </Box>
                               </Box>
                             ) : step.label !== "Departments, Statutory Institutions and Public Corporations & People" && (
                               <Typography


### PR DESCRIPTION
# Summary

pr closes #201 

- **`MinistryCard.jsx`**
  - Updated the **Name & Badge** section to iterate over the entire `card.ministers` array instead of using `card.ministers[0]`.
  - Each minister now renders with their own:
    - President label
    - Name (linked to their profile when an `id` is available)
    - **NEW** badge

- **`MinistryCardGrid.jsx`**
  - Updated the breadcrumb pills displayed after selecting a ministry to iterate over `selectedCard.ministers`.
  - Renders one pill per minister:
    - Clickable when the minister has an `id`
    - Muted/non-clickable otherwise

## Why

A ministry can have multiple concurrently appointed ministers (for example, two cabinet ministers or a cabinet minister alongside a state minister). Previously, the UI only displayed the first minister, silently hiding the others.

# Test Plan

- [x] Verify a ministry with a single minister renders identically to the previous behavior.
- [x] Verify a ministry with two or more ministers displays all ministers on:
  - The ministry tile
  - The breadcrumb pills
- [x] Verify clicking each minister's name or breadcrumb pill navigates to the correct profile page.