### PR TITLE
fix: the "people" tab issue in the minister card 

### DIFF
--- a/src/pages/OrganizationPage/components/FilteredPresidentCards.jsx
+++ b/src/pages/OrganizationPage/components/FilteredPresidentCards.jsx
@@ -95,10 +95,18 @@ export default function FilteredPresidentCards({ dateRange = [null, null] }) {
       : presStart;
     const finalEnd = rangeEnd ? new Date(Math.min(presEnd, rangeEnd)) : presEnd;
 
+    // Find if any other president starts on the same day this president ends.
+    const allRels = Object.values(presidentRelationDict);
+    const nextPresidentStartsOnSameDay = allRels.some((r) => {
+      if (!r.startTime) return false;
+      const rStart = new Date(r.startTime.split("T")[0]);
+      return rStart.getTime() === presEnd.getTime() && r !== rel;
+    });
+
     const filteredDates = gazetteDateClassic
       .filter((d) => {
         const dd = new Date(d.date);
-        return dd >= finalStart && dd < finalEnd;
+        return dd >= finalStart && (nextPresidentStartsOnSameDay ? dd < finalEnd : dd <= finalEnd);
       })
       .map((date) => (date));
 

--- a/src/pages/OrganizationPage/components/MinistryCardGrid.jsx
+++ b/src/pages/OrganizationPage/components/MinistryCardGrid.jsx
@@ -1193,7 +1193,7 @@ const MinistryCardGrid = () => {
                                         },
                                       }}
                                     >
-                                      {(selectedCard?.type === "stateMinister" ? ["departments"] : ["departments", "people"]).map((tab) => {
+                                      {(selectedCard?.type === "stateMinister" && !selectedCard?.ministers?.[0]?.id ? ["departments"] : ["departments", "people"]).map((tab) => {
                                         const label =
                                           tab.charAt(0).toUpperCase() +
                                           tab.slice(1);
@@ -1254,7 +1254,7 @@ const MinistryCardGrid = () => {
                                         gap: 2,
                                       }}
                                     >
-                                      {(selectedCard?.type === "stateMinister" ? ["departments"] : ["departments", "people"]).map((tab) => {
+                                      {(selectedCard?.type === "stateMinister" && !selectedCard?.ministers?.[0]?.id ? ["departments"] : ["departments", "people"]).map((tab) => {
                                         const label =
                                           tab.charAt(0).toUpperCase() +
                                           tab.slice(1);
@@ -1304,7 +1304,7 @@ const MinistryCardGrid = () => {
                                             ministryId={selectedCard?.id}
                                           />
                                         )}
-                                      {selectedCard && activeTab === "people" && selectedCard.type !== "stateMinister" && (
+                                      {selectedCard && activeTab === "people" && (selectedCard.type !== "stateMinister" || selectedCard?.ministers?.[0]?.id) && (
                                         <PersonsTab
                                           selectedDate={
                                             selectedDate?.date || selectedDate


### PR DESCRIPTION
- Show the "People" tab in the ministry card if the state minister has active minister persons assigned.
- Fix the issue on if the 2 presidents share the same gazette date in the timeline omitting showing the gazettes on that date for the selected presidents gazette time line
