### PR TITLE
fix: add fallback for missing minister names in MinistryCard

### DIFF
--- a/src/pages/OrganizationPage/components/MinistryCard.jsx
+++ b/src/pages/OrganizationPage/components/MinistryCard.jsx
@@ -142,8 +142,29 @@ const MinistryCard = ({ card, onClick }) => {
           {/* Name & Badge Section */}
           <Stack direction="column" spacing={1}>
             {(() => {
-              const hasMultipleMinisters = (card.ministers?.length ?? 0) > 1;
-              return (card.ministers ?? []).map((minister, idx) => (
+              const ministers = card.ministers ?? [];
+              const hasMultipleMinisters = ministers.length > 1;
+              const fallbackName = "Error Fetching Minister Name";
+
+              if (ministers.length === 0) {
+                return (
+                  <Typography
+                    variant="subtitle2"
+                    sx={{
+                      fontWeight: 400,
+                      fontSize: { xs: "0.7rem", md: "13px" },
+                      color: colors.textPrimary,
+                      fontFamily: "poppins",
+                      fontStyle: "italic",
+                      opacity: 0.7,
+                    }}
+                  >
+                    {fallbackName}
+                  </Typography>
+                );
+              }
+
+              return ministers.map((minister, idx) => (
               <Stack key={minister.id ?? `${card.id}-minister-${idx}`} direction="column" spacing={0}>
                 {/* President Label */}
                 {minister.isPresident ? (
@@ -186,7 +207,7 @@ const MinistryCard = ({ card, onClick }) => {
                     }}
                   >
                     {hasMultipleMinisters && "• "}
-                    {minister.name}
+                    {minister.name || fallbackName}
                   </Typography>
 
                   {minister.isNew && showPersonBadge && (


### PR DESCRIPTION
## Description
This PR resolves the issue https://github.com/LDFLK/openginxplore/issues/145 where the `MinistryCard` component renders a blank space when:
- The data does not include any ministers.
- The `ministers` array is empty.
- A minister object is present but does not contain a name.

A fallback string `"Error Fetching Minister Name"` has been introduced to ensure clarity and a better user experience.

## Changes
- Updated `MinistryCard.jsx`:
  - Defaulted `ministers` list to `[]`.
  - Added an early return displaying the fallback name when no ministers exist.
  - Implemented `{minister.name || fallbackName}` to handle empty or missing minister names.

<img width="1582" height="1107" alt="Screenshot 2026-08-12 at 7 53 09 PM" src="https://github.com/user-attachments/assets/780270fb-e62e-461c-8768-15f112429929" />


## Testing
- Verified locally with custom dummy data injected into the API layer.
- Rendered successfully across all fallback cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ministry cards when minister information is unavailable.
  * Displays a clear fallback message for ministries with no ministers or ministers without names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->